### PR TITLE
Use loadPartialConfig to load babel config

### DIFF
--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -1,6 +1,6 @@
 import { parse as parser, ParserOptions } from '@babel/parser';
 import { merge } from 'lodash';
-import { loadOptions } from '@babel/core';
+import { loadPartialConfig } from '@babel/core';
 import traverse, { NodePath } from '@babel/traverse';
 import { removeComments, ImportDeclaration } from '@babel/types';
 import {
@@ -21,7 +21,7 @@ export function preprocessor(code: string, options: PrettierParserOptions) {
         sourceType: 'module',
         plugins: ['typescript', 'jsx'],
     } as ParserOptions;
-    const babelConfig = loadOptions() as ParserOptions;
+    const babelConfig = loadPartialConfig() as ParserOptions;
     const mergedOptions = merge(defaultConfig, babelConfig);
 
     const ast = parser(code, mergedOptions);


### PR DESCRIPTION
In the trivago environment, we are getting the following error with `loadOptions`.
```
Error: [BABEL] unknown: Preset /* your preset */ requires a filename to be set when babel is called directly,
[error] babel.transform(code, { filename: 'file.ts', presets: [/* your preset */] });
```

I have changed the `loadOptions` with `loadPartialConfig`  https://babeljs.io/docs/en/babel-core#loadpartialconfig We just need the `presets` and `plugins` from the user's environment and `loadPartialConfig` does the job.