### PR TITLE
[#14] added keepOriginalOrderInGroups option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ is the string provided in import order.
 A boolean value to enable or disable the new line separation 
 between sorted import declarations. The separation takes place according to `importOrder`.
 
+#### `keepOriginalOrderInGroups`
+A boolean value to enable or disable sorting inside group.
+`true` value disable sorting. Default: false.
+
 #### `experimentalBabelParserPluginsList`
 A collection of parser names for babel parser. The plugin passes this list to babel parser so it can understand the syntaxes used in the file being formatted. The plugin uses prettier itself to figure out the parser it needs to use but if that fails, you can use this field to enforce the usage of the plugins babel needs.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,12 @@ const options = {
         default: false,
         description: 'Should imports be separated by new line ?',
     },
+    keepOriginalOrderInGroups: {
+        type: 'boolean',
+        category: 'Global',
+        default: false,
+        description: 'Save initial order inside groups? (default: false)',
+    },
     experimentalBabelParserPluginsList: {
         type: 'path',
         category: 'Global',

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -11,6 +11,7 @@ export function preprocessor(code: string, options: PrettierOptions) {
     const {
         importOrder,
         importOrderSeparation,
+        keepOriginalOrderInGroups,
         parser: prettierParser,
         experimentalBabelParserPluginsList = [],
     } = options;
@@ -45,6 +46,7 @@ export function preprocessor(code: string, options: PrettierOptions) {
         importNodes,
         importOrder,
         importOrderSeparation,
+        keepOriginalOrderInGroups,
     );
 
     return getCodeFromAst(allImports, code, interpreter);

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,5 +4,6 @@ import { ParserPlugin } from '@babel/parser';
 export interface PrettierOptions extends RequiredOptions {
     importOrder: string[];
     importOrderSeparation: boolean;
+    keepOriginalOrderInGroups: boolean;
     experimentalBabelParserPluginsList: ParserPlugin[];
 }

--- a/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
+++ b/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
@@ -27,7 +27,7 @@ const getSortedImportNodes = (code: string, options?: ParserOptions) => {
         },
     });
 
-    return getSortedNodes(importNodes, [], false);
+    return getSortedNodes(importNodes, [], false, false);
 };
 
 const getComments = (commentNodes: (CommentBlock | CommentLine)[]) =>

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -37,7 +37,7 @@ import k from 'k';
 import a from 'a';
 `;
     const importNodes = getImportNodes(code);
-    const sortedNodes = getSortedNodes(importNodes, [], false);
+    const sortedNodes = getSortedNodes(importNodes, [], false, false);
     const formatted = getCodeFromAst(sortedNodes, code, null);
     expect(format(formatted, { parser: 'babel' })).toEqual(
         `// first comment

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -41,7 +41,7 @@ const getSortedNodesNames = (imports: ImportDeclaration[]) =>
 
 test('it returns all sorted nodes', () => {
     const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, [], false) as ImportDeclaration[];
+    const sorted = getSortedNodes(result, [], false, false) as ImportDeclaration[];
     expect(sorted).toMatchSnapshot();
     expect(getSortedNodesNames(sorted)).toEqual(['a', 'c', 'g', 'k', 't', 'z']);
 });
@@ -52,6 +52,7 @@ test('it returns all sorted nodes with sort order', () => {
         result,
         ['^a$', '^t$', '^k$'],
         true,
+        false,
     ) as ImportDeclaration[];
     expect(sorted).toMatchSnapshot();
     expect(getSortedNodesNames(sorted)).toEqual(['c', 'g', 'z', 'a', 't', 'k']);

--- a/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
+++ b/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
@@ -39,7 +39,7 @@ import a from 'a';
 
 test('it should remove nodes from the original code', () => {
     const importNodes = getImportNodes(code);
-    const sortedNodes = getSortedNodes(importNodes, [], false);
+    const sortedNodes = getSortedNodes(importNodes, [], false, false);
     const allCommentsFromImports = getAllCommentsFromNodes(sortedNodes);
 
     const commentAndImportsToRemoveFromCode = [

--- a/src/utils/get-sorted-nodes.ts
+++ b/src/utils/get-sorted-nodes.ts
@@ -25,6 +25,7 @@ export const getSortedNodes = (
     nodes: ImportDeclaration[],
     order: PrettierOptions['importOrder'],
     importOrderSeparation: boolean,
+    keepOriginalOrderInGroups: boolean,
 ) => {
     const originalNodes = nodes.map(clone);
     const newLine =
@@ -42,7 +43,9 @@ export const getSortedNodes = (
             pull(originalNodes, ...x);
 
             if (x.length > 0) {
-                x.sort((a, b) => naturalSort(a.source.value, b.source.value));
+                if (!keepOriginalOrderInGroups) {
+                    x.sort((a, b) => naturalSort(a.source.value, b.source.value));
+                }
 
                 if (res.length > 0) {
                     return compact([...res, newLine, ...x]);
@@ -57,10 +60,11 @@ export const getSortedNodes = (
     const sortedNodesNotInImportOrder = originalNodes.filter(
         (node) => !isSimilarTextExistInArray(order, node.source.value),
     );
-
-    sortedNodesNotInImportOrder.sort((a, b) =>
-        naturalSort(a.source.value, b.source.value),
-    );
+    if (!keepOriginalOrderInGroups) {
+        sortedNodesNotInImportOrder.sort((a, b) =>
+            naturalSort(a.source.value, b.source.value),
+        );
+    }
 
     const shouldAddNewLineInBetween =
         sortedNodesNotInImportOrder.length > 0 && importOrderSeparation;

--- a/tests/KeepOriginalOrderInGroups/__snapshots__/ppsi.spec.js.snap
+++ b/tests/KeepOriginalOrderInGroups/__snapshots__/ppsi.spec.js.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`default-plus-one-group.ts - typescript-verify: default-plus-one-group.ts 1`] = `
+import styles from '../src/styles/main.module.scss';
+import { SIZE, THEMES } from '../src/components/website/vars';
+import { titleize } from '../src/components/common/utils';
+import PatternSection from '../src/components/website/components/pattern/PatternSection';
+import PatternBlock from '../src/components/website/components/pattern/PatternBlock';
+import * as React from 'react';
+import PatternHeading from '../src/components/website/components/pattern/PatternHeading';
+import cn from 'classnames';
+import { select } from '@storybook/addon-knobs';~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import * as React from "react";
+import cn from "classnames";
+import { select } from "@storybook/addon-knobs";
+
+import styles from "../src/styles/main.module.scss";
+import { SIZE, THEMES } from "../src/components/website/vars";
+import { titleize } from "../src/components/common/utils";
+import PatternSection from "../src/components/website/components/pattern/PatternSection";
+import PatternBlock from "../src/components/website/components/pattern/PatternBlock";
+import PatternHeading from "../src/components/website/components/pattern/PatternHeading";
+
+`;
+
+exports[`only-default-group.ts - typescript-verify: only-default-group.ts 1`] = `
+import * as React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { configure, addDecorator } from '@storybook/react';
+import requireContext from 'require-context.macro';~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import * as React from "react";
+import { MemoryRouter } from "react-router-dom";
+import { configure, addDecorator } from "@storybook/react";
+import requireContext from "require-context.macro";
+
+`;
+
+exports[`only-non-default-group.ts - typescript-verify: only-non-default-group.ts 1`] = `
+import { ALIGNMENT, PATTERN_LENGTH, THEMES } from '../src/components/website/vars';
+import Pattern from '../src/components/website/components/pattern/Pattern';
+import PatternHeading from '../src/components/website/components/pattern/PatternHeading';
+import PatternAvatar from '../src/components/website/components/pattern/PatternAvatar';
+import PatternParagraph from '../src/components/website/components/pattern/PatternParagraph';
+import PatternSection from '../src/components/website/components/pattern/PatternSection';
+import PatternButton from '../src/components/website/components/pattern/PatternButton';
+import PatternActions from '../src/components/website/components/pattern/PatternActions';~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import {
+    ALIGNMENT,
+    PATTERN_LENGTH,
+    THEMES,
+} from "../src/components/website/vars";
+import Pattern from "../src/components/website/components/pattern/Pattern";
+import PatternHeading from "../src/components/website/components/pattern/PatternHeading";
+import PatternAvatar from "../src/components/website/components/pattern/PatternAvatar";
+import PatternParagraph from "../src/components/website/components/pattern/PatternParagraph";
+import PatternSection from "../src/components/website/components/pattern/PatternSection";
+import PatternButton from "../src/components/website/components/pattern/PatternButton";
+import PatternActions from "../src/components/website/components/pattern/PatternActions";
+
+`;
+
+exports[`two-non-default-groups.ts - typescript-verify: two-non-default-groups.ts 1`] = `
+import Template from './components/common/Template/Template';
+import dynamicPages from './dynamic_pages/common/dynamicPages';
+import LoadingScreen from './components/common/LoadingScreen/LoadingScreen';
+
+import { ALIGNMENT, PATTERN_LENGTH, THEMES } from '../src/components/website/vars';
+import Pattern from '../src/components/website/components/pattern/Pattern';
+import PatternHeading from '../src/components/website/components/pattern/PatternHeading';
+import PatternAvatar from '../src/components/website/components/pattern/PatternAvatar';
+import PatternParagraph from '../src/components/website/components/pattern/PatternParagraph';
+import PatternSection from '../src/components/website/components/pattern/PatternSection';
+import PatternButton from '../src/components/website/components/pattern/PatternButton';
+import PatternActions from '../src/components/website/components/pattern/PatternActions';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import {
+    ALIGNMENT,
+    PATTERN_LENGTH,
+    THEMES,
+} from "../src/components/website/vars";
+import Pattern from "../src/components/website/components/pattern/Pattern";
+import PatternHeading from "../src/components/website/components/pattern/PatternHeading";
+import PatternAvatar from "../src/components/website/components/pattern/PatternAvatar";
+import PatternParagraph from "../src/components/website/components/pattern/PatternParagraph";
+import PatternSection from "../src/components/website/components/pattern/PatternSection";
+import PatternButton from "../src/components/website/components/pattern/PatternButton";
+import PatternActions from "../src/components/website/components/pattern/PatternActions";
+
+import Template from "./components/common/Template/Template";
+import dynamicPages from "./dynamic_pages/common/dynamicPages";
+import LoadingScreen from "./components/common/LoadingScreen/LoadingScreen";
+
+`;

--- a/tests/KeepOriginalOrderInGroups/default-plus-one-group.ts
+++ b/tests/KeepOriginalOrderInGroups/default-plus-one-group.ts
@@ -1,0 +1,9 @@
+import styles from '../src/styles/main.module.scss';
+import { SIZE, THEMES } from '../src/components/website/vars';
+import { titleize } from '../src/components/common/utils';
+import PatternSection from '../src/components/website/components/pattern/PatternSection';
+import PatternBlock from '../src/components/website/components/pattern/PatternBlock';
+import * as React from 'react';
+import PatternHeading from '../src/components/website/components/pattern/PatternHeading';
+import cn from 'classnames';
+import { select } from '@storybook/addon-knobs';

--- a/tests/KeepOriginalOrderInGroups/only-default-group.ts
+++ b/tests/KeepOriginalOrderInGroups/only-default-group.ts
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { configure, addDecorator } from '@storybook/react';
+import requireContext from 'require-context.macro';

--- a/tests/KeepOriginalOrderInGroups/only-non-default-group.ts
+++ b/tests/KeepOriginalOrderInGroups/only-non-default-group.ts
@@ -1,0 +1,8 @@
+import { ALIGNMENT, PATTERN_LENGTH, THEMES } from '../src/components/website/vars';
+import Pattern from '../src/components/website/components/pattern/Pattern';
+import PatternHeading from '../src/components/website/components/pattern/PatternHeading';
+import PatternAvatar from '../src/components/website/components/pattern/PatternAvatar';
+import PatternParagraph from '../src/components/website/components/pattern/PatternParagraph';
+import PatternSection from '../src/components/website/components/pattern/PatternSection';
+import PatternButton from '../src/components/website/components/pattern/PatternButton';
+import PatternActions from '../src/components/website/components/pattern/PatternActions';

--- a/tests/KeepOriginalOrderInGroups/ppsi.spec.js
+++ b/tests/KeepOriginalOrderInGroups/ppsi.spec.js
@@ -1,0 +1,9 @@
+run_spec(__dirname, ["typescript"], {
+    importOrder: [
+        "^\\.\\.",
+        "^\\./"
+    ],
+    importOrderSeparation: true,
+    experimentalBabelParserPluginsList : ["typescript"],
+    keepOriginalOrderInGroups: true
+});

--- a/tests/KeepOriginalOrderInGroups/two-non-default-groups.ts
+++ b/tests/KeepOriginalOrderInGroups/two-non-default-groups.ts
@@ -1,0 +1,12 @@
+import Template from './components/common/Template/Template';
+import dynamicPages from './dynamic_pages/common/dynamicPages';
+import LoadingScreen from './components/common/LoadingScreen/LoadingScreen';
+
+import { ALIGNMENT, PATTERN_LENGTH, THEMES } from '../src/components/website/vars';
+import Pattern from '../src/components/website/components/pattern/Pattern';
+import PatternHeading from '../src/components/website/components/pattern/PatternHeading';
+import PatternAvatar from '../src/components/website/components/pattern/PatternAvatar';
+import PatternParagraph from '../src/components/website/components/pattern/PatternParagraph';
+import PatternSection from '../src/components/website/components/pattern/PatternSection';
+import PatternButton from '../src/components/website/components/pattern/PatternButton';
+import PatternActions from '../src/components/website/components/pattern/PatternActions';


### PR DESCRIPTION
Hi,
added option `keepOriginalOrderInGroups`, that saves initial order of imports, but still sorts import by groups(RegEx).
The option allows easy transition to prettier without many git changes in the codebase.


BTW
I like how this option realized in [ImportSorter extension](https://marketplace.visualstudio.com/items?itemName=mike-co.import-sorter#:~:text=Extension%20which%20sorts%20TypeScript%20imports,set%20sorting%20priority%20and%20rules.) for VSCode
My config for it (I trying to migrate from importSorter extension to prettier plugin)
```
"importSorter.generalConfiguration.sortOnBeforeSave": false,
"importSorter.importStringConfiguration.quoteMark": "single",
"importSorter.importStringConfiguration.tabType": "space",
"importSorter.importStringConfiguration.tabSize": 2,
"importSorter.importStringConfiguration.trailingComma": "multiLine",
"importSorter.importStringConfiguration.maximumNumberOfImportExpressionsPerLine.count": 96,
"importSorter.importStringConfiguration.maximumNumberOfImportExpressionsPerLine.type": "maxLineLength",
"importSorter.sortConfiguration.removeUnusedImports": true,
"importSorter.sortConfiguration.removeUnusedDefaultImports": false,
"importSorter.sortConfiguration.joinImportPaths": true,
"importSorter.sortConfiguration.importMembers.order": "unsorted",
"importSorter.sortConfiguration.customOrderingRules.defaultOrderLevel": 21,
"importSorter.sortConfiguration.customOrderingRules.disableDefaultOrderSort": false,
"importSorter.sortConfiguration.customOrderingRules.defaultNumberOfEmptyLinesAfterGroup": 1,
"importSorter.sortConfiguration.customOrderingRules.rules": [
	{
		"regex": "^(assert|buffer|child_process|cluster|crypto|dgram|dns|domain|events|fs|http|https|net|os|path|punycode|querystring|readline|stream|string_decoder|timers|tls|tty|url|util|v8|vm|zlib)$",
		"orderLevel": 10,
		"disableSort": true
	},
	{
		"regex": "^[A-Za-z_@][.]*",
		"orderLevel": 20,
		"disableSort": true
	},
	{
		"regex": "^[.][.]",
		"orderLevel": 40,
		"disableSort": true
	},
	{
		"regex": "^[.]/",
		"orderLevel": 50,
		"disableSort": true
	}
],
```