### PR TITLE
[#62] rely on prettier type to fix type error

### DIFF
--- a/src/utils/get-parser-plugins.ts
+++ b/src/utils/get-parser-plugins.ts
@@ -1,5 +1,5 @@
 import { ParserPlugin } from '@babel/parser';
-import { BuiltInParserName, CustomParser } from 'prettier';
+import { RequiredOptions } from 'prettier';
 import {
     flow,
     typescript,
@@ -14,7 +14,7 @@ import {
  * @returns list of parser plugins to be passed to babel parser
  */
 export const getParserPlugins = (
-    prettierParser: BuiltInParserName | CustomParser,
+    prettierParser: RequiredOptions['parser'],
 ): ParserPlugin[] => {
     const isFlow = prettierParser === flow;
     const isTypescript = prettierParser === typescript;


### PR DESCRIPTION
## Issue?

Typescript error in the `getParserPlugins` function.

> [line 18 of `src/preprocessor.ts`](https://github.com/trivago/prettier-plugin-sort-imports/blob/ab7fad40eb67241957eb77dc59539dcf9e0699db/src/preprocessor.ts#L18) stating:
> 
> ```ts
> Argument of type 'LiteralUnion<BuiltInParserName, string> | CustomParser' is not assignable to parameter of type 'BuiltInParserName | CustomParser'.
>   Type 'Pick<string, never> & { _?: undefined; }' is not assignable to type 'BuiltInParserName | CustomParser'.
>     Type 'Pick<string, never> & { _?: undefined; }' is not assignable to type 'CustomParser'.
>       Type 'Pick<string, never> & { _?: undefined; }' provides no match for the signature '(text: string, parsers: BuiltInParsers, options: Options): any'.ts(2345)
> ```
> 
> #62

Closes #62 

## How this fixes it?

Prettier's parser type from RequiredOptions is expected and is made explicit.
