### PR TITLE
Try fix install not working with Prettier 2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
     "@babel/types": "7.13.0",
     "@types/lodash": "4.14.168",
     "javascript-natural-sort": "0.7.1",
-    "lodash": "4.17.21",
-    "prettier": "2.2.1"
+    "lodash": "4.17.21"
   },
   "devDependencies": {
     "@types/chai": "4.2.15",
     "@types/jest": "26.0.20",
     "@types/node": "14.14.34",
     "jest": "26.6.3",
+    "prettier": "2.3.1",
     "ts-jest": "26.5.3",
     "typescript": "4.2.3"
   },

--- a/src/utils/get-parser-plugins.ts
+++ b/src/utils/get-parser-plugins.ts
@@ -1,5 +1,5 @@
 import { ParserPlugin } from '@babel/parser';
-import { BuiltInParserName, CustomParser } from 'prettier';
+import { RequiredOptions } from 'prettier';
 import {
     flow,
     typescript,
@@ -14,7 +14,7 @@ import {
  * @returns list of parser plugins to be passed to babel parser
  */
 export const getParserPlugins = (
-    prettierParser: BuiltInParserName | CustomParser,
+    prettierParser: RequiredOptions['parser'],
 ): ParserPlugin[] => {
     const isFlow = prettierParser === flow;
     const isTypescript = prettierParser === typescript;


### PR DESCRIPTION
This PR tries to fix https://github.com/trivago/prettier-plugin-sort-imports/issues/61

Cherry-picked commit from https://github.com/trivago/prettier-plugin-sort-imports/pull/63 from @JamesGelok to fix `tsc` not working.