### PR TITLE
Fix faulty comment replace in removeNodesFromOriginalCode

### DIFF
--- a/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
+++ b/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
@@ -34,6 +34,8 @@ import c from 'c';
 import g from 'g';
 import t from 't';
 import k from 'k';
+// import a from 'a';
+  // import a from 'a';
 import a from 'a';
 `;
 

--- a/src/utils/remove-nodes-from-original-code.ts
+++ b/src/utils/remove-nodes-from-original-code.ts
@@ -6,6 +6,11 @@ import {
     InterpreterDirective,
 } from '@babel/types';
 
+/** Escapes a string literal to be passed to new RegExp. See: https://stackoverflow.com/a/6969486/480608.
+ * @param s the string to escape
+ */
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 /**
  * Removes imports from original file
  * @param code the whole file as text
@@ -26,7 +31,15 @@ export const removeNodesFromOriginalCode = (
         const start = Number(node.start);
         const end = Number(node.end);
         if (Number.isSafeInteger(start) && Number.isSafeInteger(end)) {
-            text = text.replace(code.substring(start, end), '');
+            text = text.replace(
+                // only replace imports at the beginning of the line (ignoring whitespace)
+                // otherwise matching commented imports will be replaced
+                new RegExp(
+                    '^\\s*' + escapeRegExp(code.substring(start, end)),
+                    'm',
+                ),
+                '',
+            );
         }
     }
     return text;


### PR DESCRIPTION
Fixes #55

The cause of #55 is that `removeNodesFromOriginalCode` accidentally removes the import from the matching comment if it comes earlier in the source.

I couldn't figure out a way to do this without `new RegExp`. I tried 🙂. I'm not sure if you can constrain the scope of the replace or if it has to replace from all code.