### PR TITLE
Option to group namespace specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ A prettier plugin to sort import declarations by provided Regular Expression ord
 **Note: If you are migrating from v2.x.x to v3.x.x, [Please Read Migration Guidelines](./docs/MIGRATION.md)**
 
 ### Input
+
 ![input](./public/images/input-v3-1.png)
 
 ### Output
-![output](./public/images/output-v3-1.png)
 
+![output](./public/images/output-v3-1.png)
 
 ### Install
 
@@ -24,7 +25,6 @@ or, using yarn
 ```shell script
 yarn add --dev @trivago/prettier-plugin-sort-imports
 ```
-
 
 **Note: If you are migrating from v2.x.x to v3.x.x, [Please Read Migration Guidelines](./docs/MIGRATION.md)**
 
@@ -47,18 +47,19 @@ module.exports = {
 
 ### APIs
 
-#### **`importOrder`** 
+#### **`importOrder`**
 
 **type**: `Array<string>`
 
-A collection of Regular expressions in string format. 
+A collection of Regular expressions in string format.
 
 ```
 "importOrder": ["^@core/(.*)$", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"],
 ```
 
-_Default behavior:_ The plugin moves the third party imports to the top which are not part of the `importOrder` list. 
+_Default behavior:_ The plugin moves the third party imports to the top which are not part of the `importOrder` list.
 To move the third party imports at desired place, you can use `<THIRD_PARTY_MODULES>` to assign third party imports to the appropriate position:
+
 ```
 "importOrder": ["^@core/(.*)$", "<THIRD_PARTY_MODULES>", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"],
 ```
@@ -69,7 +70,7 @@ To move the third party imports at desired place, you can use `<THIRD_PARTY_MODU
 
 **default value**: `false`
 
-A boolean value to enable or disable the new line separation 
+A boolean value to enable or disable the new line separation
 between sorted import declarations group. The separation takes place according to the `importOrder`.
 
 ```
@@ -84,6 +85,13 @@ between sorted import declarations group. The separation takes place according t
 
 A boolean value to enable or disable sorting of the specifiers in an import declarations.
 
+#### `importOrderGroupNamespaceSpecifiers`
+
+**type**: `boolean`
+
+**default value:** `false`
+
+A boolean value to enable or disable sorting the namespace specifiers to the top of the import group.
 
 #### `importOrderCaseInsensitive`
 
@@ -116,17 +124,18 @@ import ExampleView from './ExampleView';
 
 Previously known as `experimentalBabelParserPluginsList`.
 
-A collection of plugins for babel parser. The plugin passes this list to babel parser, so it can understand the syntaxes 
+A collection of plugins for babel parser. The plugin passes this list to babel parser, so it can understand the syntaxes
 used in the file being formatted. The plugin uses prettier itself to figure out the parser it needs to use but if that fails,
 you can use this field to enforce the usage of the plugins' babel parser needs.
 
 **To pass the plugins to babel parser**:
+
 ```
   "importOrderParserPlugins" : ["classProperties", "decorators-legacy"]
 ```
 
-**To pass the options to the babel parser plugins**: Since prettier options are limited to string, you can pass plugins 
-with options as a JSON string of the plugin array: 
+**To pass the options to the babel parser plugins**: Since prettier options are limited to string, you can pass plugins
+with options as a JSON string of the plugin array:
 `"[\"plugin-name\", { \"pluginOption\": true }]"`.
 
 ```
@@ -134,13 +143,14 @@ with options as a JSON string of the plugin array:
 ```
 
 **To disable default plugins for babel parser, pass an empty array**:
+
 ```
 importOrderParserPlugins: []
 ```
 
 ### How does import sort work ?
 
-The plugin extracts the imports which are defined in `importOrder`. These imports are considered as _local imports_. 
+The plugin extracts the imports which are defined in `importOrder`. These imports are considered as _local imports_.
 The imports which are not part of the `importOrder` is considered as _third party imports_.
 
 After, the plugin sorts the _local imports_ and _third party imports_ using [natural sort algorithm](https://en.wikipedia.org/wiki/Natural_sort_order).
@@ -153,33 +163,37 @@ The _third party imports_ position (it's top by default) can be overridden using
 
 Having some trouble or an issue ? You can check [FAQ / Troubleshooting section](./docs/TROUBLESHOOTING.md).
 
-
 ### Compatibility
-| Framework | Supported                                | Note                         |
-|-----------|------------------------------------------|------------------------------|
-| JS with ES Modules     | ✅ Everything                              | -                            |
-| NodeJS with ES Modules     | ✅ Everything                              | -                            |
-| React     | ✅ Everything                              | -                            |
-| Angular   | ✅ Everything   | Supported through `importOrderParserPlugins` API  |
-| Vue       | ⚠️ Soon to be supported.                           | Any contribution is welcome. |
-| Svelte    | ⚠️ Soon to be supported.                             | Any contribution is welcome. |
+
+| Framework              | Supported                | Note                                             |
+| ---------------------- | ------------------------ | ------------------------------------------------ |
+| JS with ES Modules     | ✅ Everything            | -                                                |
+| NodeJS with ES Modules | ✅ Everything            | -                                                |
+| React                  | ✅ Everything            | -                                                |
+| Angular                | ✅ Everything            | Supported through `importOrderParserPlugins` API |
+| Vue                    | ⚠️ Soon to be supported. | Any contribution is welcome.                     |
+| Svelte                 | ⚠️ Soon to be supported. | Any contribution is welcome.                     |
 
 ### Used by
+
 Want to highlight your project or company ? Adding your project / company name will help plugin to gain attraction and contribution.
 Feel free to make a Pull Request to add your project / company name.
-- [trivago](https://company.trivago.com)
-- ADD YOUR PROJECT / COMPANY NAME
+
+-   [trivago](https://company.trivago.com)
+-   ADD YOUR PROJECT / COMPANY NAME
 
 ### Contribution
+
 For more information regarding contribution, please check the [Contributing Guidelines](./CONTRIBUTING.md). If you are trying to
 debug some code in the plugin, check [Debugging Guidelines](./docs/DEBUG.md)
 
 ### Maintainers
 
-|  [Ayush Sharma](https://github.com/ayusharma) | [Behrang Yarahmadi](https://github.com/byara)
-|---|---|
-| ![ayusharma](https://avatars2.githubusercontent.com/u/6918450?s=120&v=4) | ![@byara](https://avatars2.githubusercontent.com/u/6979966?s=120&v=4)
-| [@ayusharma_](https://twitter.com/ayusharma_) | [@behrang_y](https://twitter.com/behrang_y)
+| [Ayush Sharma](https://github.com/ayusharma)                             | [Behrang Yarahmadi](https://github.com/byara)                         |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| ![ayusharma](https://avatars2.githubusercontent.com/u/6918450?s=120&v=4) | ![@byara](https://avatars2.githubusercontent.com/u/6979966?s=120&v=4) |
+| [@ayusharma\_](https://twitter.com/ayusharma_)                           | [@behrang_y](https://twitter.com/behrang_y)                           |
 
 ### Disclaimer
+
 This plugin modifies the AST which is against the rules of prettier.

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,8 @@ const options = {
         type: 'boolean',
         category: 'Global',
         default: false,
-        description: 'Should namespace specifies be grouped at the top?',
+        description:
+            'Should namespace specifiers be grouped at the top of their group?',
     },
     importOrderSortSpecifiers: {
         type: 'boolean',

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,12 @@ const options = {
         default: false,
         description: 'Should imports be separated by new line?',
     },
+    importOrderGroupNamespaceSpecifiers: {
+        type: 'boolean',
+        category: 'Global',
+        default: false,
+        description: 'Should namespace specifies be grouped at the top?',
+    },
     importOrderSortSpecifiers: {
         type: 'boolean',
         category: 'Global',

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -13,6 +13,7 @@ export function preprocessor(code: string, options: PrettierOptions) {
         importOrder,
         importOrderCaseInsensitive,
         importOrderSeparation,
+        importOrderGroupNamespaceSpecifiers,
         importOrderSortSpecifiers,
     } = options;
 
@@ -43,6 +44,7 @@ export function preprocessor(code: string, options: PrettierOptions) {
         importOrder,
         importOrderCaseInsensitive,
         importOrderSeparation,
+        importOrderGroupNamespaceSpecifiers,
         importOrderSortSpecifiers,
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface PrettierOptions extends RequiredOptions {
     // should be of type ParserPlugin from '@babel/parser' but prettier does not support nested arrays in options
     importOrderParserPlugins: string[];
     importOrderSeparation: boolean;
+    importOrderGroupNamespaceSpecifiers: boolean;
     importOrderSortSpecifiers: boolean;
 }
 
@@ -20,6 +21,7 @@ export type GetSortedNodes = (
         | 'importOrder'
         | 'importOrderCaseInsensitive'
         | 'importOrderSeparation'
+        | 'importOrderGroupNamespaceSpecifiers'
         | 'importOrderSortSpecifiers'
     >,
 ) => ImportOrLine[];

--- a/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
+++ b/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
@@ -11,6 +11,7 @@ const getSortedImportNodes = (code: string, options?: ParserOptions) => {
         importOrder: [],
         importOrderCaseInsensitive: false,
         importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
     });
 };

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -18,6 +18,7 @@ import a from 'a';
         importOrder: [],
         importOrderCaseInsensitive: false,
         importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
     });
     const formatted = getCodeFromAst(sortedNodes, code, null);

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -12,6 +12,7 @@ import g from 'g';
 import { tC, tA, tB } from 't';
 import k, { kE, kB } from 'k';
 import * as a from 'a';
+import * as x from 'x';
 import BY from 'BY';
 import Ba from 'Ba';
 import XY from 'XY';
@@ -24,14 +25,29 @@ test('it returns all sorted nodes', () => {
         importOrder: [],
         importOrderCaseInsensitive: false,
         importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
 
-    expect(getSortedNodesNames(sorted)).toEqual(['BY', 'Ba', 'XY', 'Xa', 'a', 'c', 'g', 'k', 't', 'z']);
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'BY',
+        'Ba',
+        'XY',
+        'Xa',
+        'a',
+        'c',
+        'g',
+        'k',
+        't',
+        'x',
+        'z',
+    ]);
     expect(
         sorted
             .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) => getSortedNodesModulesNames(importDeclaration.specifiers)),
+            .map((importDeclaration) =>
+                getSortedNodesModulesNames(importDeclaration.specifiers),
+            ),
     ).toEqual([
         ['BY'],
         ['Ba'],
@@ -42,6 +58,7 @@ test('it returns all sorted nodes', () => {
         ['g'],
         ['k', 'kE', 'kB'],
         ['tC', 'tA', 'tB'],
+        ['x'],
         ['z'],
     ]);
 });
@@ -52,14 +69,29 @@ test('it returns all sorted nodes case-insensitive', () => {
         importOrder: [],
         importOrderCaseInsensitive: true,
         importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
 
-    expect(getSortedNodesNames(sorted)).toEqual(['a', 'Ba', 'BY', 'c', 'g', 'k', 't', 'Xa', 'XY', 'z']);
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'a',
+        'Ba',
+        'BY',
+        'c',
+        'g',
+        'k',
+        't',
+        'x',
+        'Xa',
+        'XY',
+        'z',
+    ]);
     expect(
         sorted
             .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) => getSortedNodesModulesNames(importDeclaration.specifiers)),
+            .map((importDeclaration) =>
+                getSortedNodesModulesNames(importDeclaration.specifiers),
+            ),
     ).toEqual([
         ['a'],
         ['Ba'],
@@ -68,6 +100,7 @@ test('it returns all sorted nodes case-insensitive', () => {
         ['g'],
         ['k', 'kE', 'kB'],
         ['tC', 'tA', 'tB'],
+        ['x'],
         ['Xa'],
         ['XY'],
         ['z'],
@@ -80,19 +113,35 @@ test('it returns all sorted nodes with sort order', () => {
         importOrder: ['^a$', '^t$', '^k$', '^B'],
         importOrderCaseInsensitive: false,
         importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
 
-    expect(getSortedNodesNames(sorted)).toEqual(['XY', 'Xa', 'c', 'g', 'z', 'a', 't', 'k', 'BY', 'Ba']);
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'XY',
+        'Xa',
+        'c',
+        'g',
+        'x',
+        'z',
+        'a',
+        't',
+        'k',
+        'BY',
+        'Ba',
+    ]);
     expect(
         sorted
             .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) => getSortedNodesModulesNames(importDeclaration.specifiers)),
+            .map((importDeclaration) =>
+                getSortedNodesModulesNames(importDeclaration.specifiers),
+            ),
     ).toEqual([
         ['XY'],
         ['Xa'],
         ['c', 'cD'],
         ['g'],
+        ['x'],
         ['z'],
         ['a'],
         ['tC', 'tA', 'tB'],
@@ -108,16 +157,32 @@ test('it returns all sorted nodes with sort order case-insensitive', () => {
         importOrder: ['^a$', '^t$', '^k$', '^B'],
         importOrderCaseInsensitive: true,
         importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual(['c', 'g', 'Xa', 'XY', 'z', 'a', 't', 'k', 'Ba', 'BY']);
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'c',
+        'g',
+        'x',
+        'Xa',
+        'XY',
+        'z',
+        'a',
+        't',
+        'k',
+        'Ba',
+        'BY',
+    ]);
     expect(
         sorted
             .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) => getSortedNodesModulesNames(importDeclaration.specifiers)),
+            .map((importDeclaration) =>
+                getSortedNodesModulesNames(importDeclaration.specifiers),
+            ),
     ).toEqual([
         ['c', 'cD'],
         ['g'],
+        ['x'],
         ['Xa'],
         ['XY'],
         ['z'],
@@ -135,18 +200,34 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
         importOrder: ['^a$', '^t$', '^k$', '^B'],
         importOrderCaseInsensitive: false,
         importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: true,
     }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual(['XY', 'Xa', 'c', 'g', 'z', 'a', 't', 'k', 'BY', 'Ba']);
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'XY',
+        'Xa',
+        'c',
+        'g',
+        'x',
+        'z',
+        'a',
+        't',
+        'k',
+        'BY',
+        'Ba',
+    ]);
     expect(
         sorted
             .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) => getSortedNodesModulesNames(importDeclaration.specifiers)),
+            .map((importDeclaration) =>
+                getSortedNodesModulesNames(importDeclaration.specifiers),
+            ),
     ).toEqual([
         ['XY'],
         ['Xa'],
         ['c', 'cD'],
         ['g'],
+        ['x'],
         ['z'],
         ['a'],
         ['tA', 'tB', 'tC'],
@@ -162,16 +243,32 @@ test('it returns all sorted import nodes with sorted import specifiers with case
         importOrder: ['^a$', '^t$', '^k$', '^B'],
         importOrderCaseInsensitive: true,
         importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: true,
     }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual(['c', 'g', 'Xa', 'XY', 'z', 'a', 't', 'k', 'Ba', 'BY']);
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'c',
+        'g',
+        'x',
+        'Xa',
+        'XY',
+        'z',
+        'a',
+        't',
+        'k',
+        'Ba',
+        'BY',
+    ]);
     expect(
         sorted
             .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) => getSortedNodesModulesNames(importDeclaration.specifiers)),
+            .map((importDeclaration) =>
+                getSortedNodesModulesNames(importDeclaration.specifiers),
+            ),
     ).toEqual([
         ['c', 'cD'],
         ['g'],
+        ['x'],
         ['Xa'],
         ['XY'],
         ['z'],
@@ -189,7 +286,45 @@ test('it returns all sorted nodes with custom third party modules', () => {
         importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$'],
         importOrderSeparation: false,
         importOrderCaseInsensitive: true,
+        importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual(['a', 'Ba', 'BY', 'c', 'g', 'Xa', 'XY', 'z', 't', 'k']);
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'a',
+        'Ba',
+        'BY',
+        'c',
+        'g',
+        'x',
+        'Xa',
+        'XY',
+        'z',
+        't',
+        'k',
+    ]);
+});
+
+test('it returns all sorted nodes with namespace specifiers at the top', () => {
+    const result = getImportNodes(code);
+    const sorted = getSortedNodes(result, {
+        importOrder: [],
+        importOrderCaseInsensitive: false,
+        importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: true,
+        importOrderSortSpecifiers: false,
+    }) as ImportDeclaration[];
+
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'a',
+        'x',
+        'BY',
+        'Ba',
+        'XY',
+        'Xa',
+        'c',
+        'g',
+        'k',
+        't',
+        'z',
+    ]);
 });

--- a/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
+++ b/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
@@ -22,6 +22,7 @@ test('it should remove nodes from the original code', () => {
         importOrder: [],
         importOrderCaseInsensitive: false,
         importOrderSeparation: false,
+        importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
     });
     const allCommentsFromImports = getAllCommentsFromNodes(sortedNodes);

--- a/src/utils/get-sorted-nodes-group.ts
+++ b/src/utils/get-sorted-nodes-group.ts
@@ -1,0 +1,31 @@
+import { Import, ImportDeclaration } from '@babel/types';
+import { naturalSort } from '../natural-sort';
+import { PrettierOptions } from '../types';
+
+export const getSortedNodesGroup = (
+    imports: ImportDeclaration[],
+    options: Pick<PrettierOptions, 'importOrderGroupNamespaceSpecifiers'>,
+) => {
+    return imports.sort((a, b) => {
+        if (options.importOrderGroupNamespaceSpecifiers) {
+            const diff = namespaceSpecifierSort(a, b);
+            if (diff !== 0) return diff;
+        }
+
+        return naturalSort(a.source.value, b.source.value);
+    });
+};
+
+function namespaceSpecifierSort(a: ImportDeclaration, b: ImportDeclaration) {
+    const aFirstSpecifier = a.specifiers.find(
+        (s) => s.type === 'ImportNamespaceSpecifier',
+    )
+        ? 1
+        : 0;
+    const bFirstSpecifier = b.specifiers.find(
+        (s) => s.type === 'ImportNamespaceSpecifier',
+    )
+        ? 1
+        : 0;
+    return bFirstSpecifier - aFirstSpecifier;
+}

--- a/src/utils/get-sorted-nodes.ts
+++ b/src/utils/get-sorted-nodes.ts
@@ -1,15 +1,13 @@
 import { naturalSort } from '../natural-sort';
 import { isEqual, clone } from 'lodash';
 
-import {
-    addComments,
-    removeComments,
-} from '@babel/types';
+import { addComments, removeComments } from '@babel/types';
 
 import { GetSortedNodes, ImportGroups, ImportOrLine } from '../types';
 import { newLineNode, THIRD_PARTY_MODULES_SPECIAL_WORD } from '../constants';
 import { getSortedImportSpecifiers } from './get-sorted-import-specifiers';
 import { getImportNodesMatchedGroup } from './get-import-nodes-matched-group';
+import { getSortedNodesGroup } from './get-sorted-nodes-group';
 
 /**
  * This function returns all the nodes which are in the importOrder array.
@@ -21,7 +19,11 @@ export const getSortedNodes: GetSortedNodes = (nodes, options) => {
     naturalSort.insensitive = options.importOrderCaseInsensitive;
 
     let { importOrder } = options;
-    const { importOrderSeparation, importOrderSortSpecifiers } = options;
+    const {
+        importOrderSeparation,
+        importOrderSortSpecifiers,
+        importOrderGroupNamespaceSpecifiers,
+    } = options;
 
     const originalNodes = nodes.map(clone);
     const finalNodes: ImportOrLine[] = [];
@@ -55,9 +57,9 @@ export const getSortedNodes: GetSortedNodes = (nodes, options) => {
 
         if (groupNodes.length === 0) continue;
 
-        const sortedInsideGroup = groupNodes.sort((a, b) =>
-            naturalSort(a.source.value, b.source.value),
-        );
+        const sortedInsideGroup = getSortedNodesGroup(groupNodes, {
+            importOrderGroupNamespaceSpecifiers,
+        });
 
         // Sort the import specifiers
         if (importOrderSortSpecifiers) {


### PR DESCRIPTION
This PR adds the `importOrderGroupNamespaceSpecifiers` config variable. When true it groups `import * as lib from 'lib'` imports to the top of the group.

Closes #104 