### PR TITLE
Do not reorder side effect nodes #110

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,62 @@
+---
+name: Bug report 🐛
+about: A feature is not working as is expected, I want to report a bug
+labels: 'investigation'
+title: ''
+assignees: ''
+---
+
+<!-- PLEASE READ THIS:  
+ - If you are not sure is a bug, OPEN a DISCUSSION, if is a legitimate bug, is easy to create a bug from a discussion.
+ - Empty reports won't be considered and eventually be closed by a bot.
+ - Include debugging notes will help to fix it faster.
+ - If you remove this template, ticket will be closed immediately.
+ - No English perfect is required, use public translators if is need it, we will do our best to help you.
+ - Extra bonus: The most complete this report is delivered, the faster you will get a response.
+ - Extra bonus: include screenshots, logs (remove sensitive data).
+ - If you are willing to fix it, there is a checkbox at the bottom.
+-->
+
+**Your Environment**
+ * **Prettier version**: 2.x.x
+ * **node version** [12.x.x, 14.x.x]:
+ * **package manager**: [npm@7, pnpm@6, yarn@2]
+ * **IDE**: [VScode, Webstorm, CLI]
+
+**Describe the bug**
+
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+
+<!-- IMPORTANT:
+ - How to reproduce the issue
+ - Steps to reproduce the issue
+
+Be aware, the lack of reproducible steps the issue might cause your ticket to be closed.
+-->
+
+**Expected behavior**
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Screenshots, code sample, etc**
+
+<!-- If applicable, add screenshots to help explain your problem.  -->
+
+**Configuration File (cat .prettierrc, prettier.config.js, .prettier.js)**
+
+<!-- Please be careful do not leak any sensitive information, remove tokens -->
+
+**Error log**
+
+<!-- A clear and concise description. -->
+
+**Contribute to @trivago/prettier-plugin-sort-imports**
+
+- [ ] I'm willing to fix this bug 🥇 
+
+<!--
+
+IMPORTANT: please do not attach external files, all content should be visible from any device.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question 🤷🏻‍♂️
+    url: https://github.com/trivago/prettier-plugin-sort-imports/discussions/new?category=q-a
+    about: 🆕 Open a new Q&A discussion 🙏

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,26 @@
+---
+name: 'Feature Request 🔮'
+about: You want a feature request.
+title: ''
+labels: 'feature request'
+assignees: ''
+---
+
+<!--
+IMPORTANT: If you don't have an action plan, please consider create a DISCUSSION (idea) instead for an open a feature request issue.
+
+https://github.com/trivago/prettier-plugin-sort-imports/discussions/new
+
+-->
+
+**Is your feature request related to a problem?**
+Please describe a clear and concise description of what the problem is. E.g. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,35 @@ importOrderParserPlugins: []
 The plugin extracts the imports which are defined in `importOrder`. These imports are considered as _local imports_. 
 The imports which are not part of the `importOrder` is considered as _third party imports_.
 
-After, the plugin sorts the _local imports_ and _third party imports_ using [natural sort algorithm](https://en.wikipedia.org/wiki/Natural_sort_order).
+First, the plugin checks for
+[side effect imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#import_a_module_for_its_side_effects_only),
+such as `import 'mock-fs'`. These imports often modify the global scope or apply some patches to the current
+environment, which may affect other imports. To preserve potential side effects, these kind of side effect imports are
+not sorted. They also behave as a barrier that other imports may not cross during the sort. So for example, let's say
+you've got these imports:
+
+```javascript
+import E from 'e';
+import F from 'f';
+import D from 'd';
+import 'c';
+import B from 'b';
+import A from 'a';
+```
+
+Then the first three imports are sorted and the last two imports are sorted, but all imports above `c` stay above `c`
+and all imports below `c` stay below `c`, resulting in:
+
+```javascript
+import D from 'd';
+import E from 'e';
+import F from 'f';
+import 'c';
+import A from 'a';
+import B from 'b';
+```
+
+Next, the plugin sorts the _local imports_ and _third party imports_ using [natural sort algorithm](https://en.wikipedia.org/wiki/Natural_sort_order).
 
 In the end, the plugin returns final imports with _third party imports_ on top and _local imports_ at the end.
 

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   "devDependencies": {
     "@types/chai": "4.2.15",
     "@types/jest": "26.0.20",
-    "@types/node": "14.14.34",
     "@types/lodash": "4.14.168",
+    "@types/node": "14.14.34",
     "jest": "26.6.3",
     "prettier": "2.3.1",
     "ts-jest": "26.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trivago/prettier-plugin-sort-imports",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A prettier plugins to sort imports in provided RegEx order",
   "main": "lib/src/index.js",
   "repository": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,8 +7,8 @@ export const jsx: ParserPlugin = 'jsx';
 
 export const newLineCharacters = '\n\n';
 
-export const ChunkSideEffectNode = 'side-effect-node';
-export const ChunkSideOtherNode = 'other-node';
+export const chunkSideEffectNode = 'side-effect-node';
+export const chunkSideOtherNode = 'other-node';
 
 /*
  * Used to mark the position between RegExps,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,9 @@ export const jsx: ParserPlugin = 'jsx';
 
 export const newLineCharacters = '\n\n';
 
+export const ChunkSideEffectNode = 'side-effect-node';
+export const ChunkSideOtherNode = 'other-node';
+
 /*
  * Used to mark the position between RegExps,
  * where the not matched imports should be placed

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,11 @@ export interface PrettierOptions extends RequiredOptions {
     importOrderSortSpecifiers: boolean;
 }
 
+export interface ImportChunk {
+    nodes: ImportDeclaration[];
+    type: string;
+}
+
 export type ImportGroups = Record<string, ImportDeclaration[]>;
 export type ImportOrLine = ImportDeclaration | ExpressionStatement;
 

--- a/src/utils/__tests__/adjust-comments-on-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/adjust-comments-on-sorted-nodes.spec.ts
@@ -1,0 +1,107 @@
+import { ImportDeclaration } from '@babel/types';
+
+import { adjustCommentsOnSortedNodes } from '../adjust-comments-on-sorted-nodes';
+import { getImportNodes } from '../get-import-nodes';
+
+function leadingComments(node: ImportDeclaration): string[] {
+    return node.leadingComments?.map((c) => c.value) ?? [];
+}
+
+function trailingComments(node: ImportDeclaration): string[] {
+    return node.trailingComments?.map((c) => c.value) ?? [];
+}
+
+test('it preserves the single leading comment for each import declaration', () => {
+    const importNodes = getImportNodes(`
+    import {x} from "c";
+    // comment b
+    import {y} from "b";
+    // comment a
+    import {z} from "a";
+    `);
+    expect(importNodes).toHaveLength(3);
+    const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
+    adjustCommentsOnSortedNodes(importNodes, finalNodes);
+    expect(finalNodes).toHaveLength(3);
+    expect(leadingComments(finalNodes[0])).toEqual([' comment a']);
+    expect(trailingComments(finalNodes[0])).toEqual([]);
+    expect(leadingComments(finalNodes[1])).toEqual([' comment b']);
+    expect(trailingComments(finalNodes[1])).toEqual([]);
+    expect(leadingComments(finalNodes[2])).toEqual([]);
+    expect(trailingComments(finalNodes[2])).toEqual([]);
+});
+
+test('it preserves multiple leading comments for each import declaration', () => {
+    const importNodes = getImportNodes(`
+    import {x} from "c";
+    // comment b1
+    // comment b2
+    // comment b3
+    import {y} from "b";
+    // comment a1
+    // comment a2
+    // comment a3
+    import {z} from "a";
+    `);
+    expect(importNodes).toHaveLength(3);
+    const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
+    adjustCommentsOnSortedNodes(importNodes, finalNodes);
+    expect(finalNodes).toHaveLength(3);
+    expect(leadingComments(finalNodes[0])).toEqual([
+        ' comment a1',
+        ' comment a2',
+        ' comment a3',
+    ]);
+    expect(trailingComments(finalNodes[0])).toEqual([]);
+    expect(leadingComments(finalNodes[1])).toEqual([
+        ' comment b1',
+        ' comment b2',
+        ' comment b3',
+    ]);
+    expect(trailingComments(finalNodes[1])).toEqual([]);
+    expect(leadingComments(finalNodes[2])).toEqual([]);
+    expect(trailingComments(finalNodes[2])).toEqual([]);
+});
+
+test('it does not move comments at before all import declarations', () => {
+    const importNodes = getImportNodes(`
+    // comment c1
+    // comment c2
+    import {x} from "c";
+    import {y} from "b";
+    import {z} from "a";
+    `);
+    expect(importNodes).toHaveLength(3);
+    const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
+    adjustCommentsOnSortedNodes(importNodes, finalNodes);
+    expect(finalNodes).toHaveLength(3);
+    expect(leadingComments(finalNodes[0])).toEqual([
+        ' comment c1',
+        ' comment c2',
+    ]);
+    expect(trailingComments(finalNodes[0])).toEqual([]);
+    expect(leadingComments(finalNodes[1])).toEqual([]);
+    expect(trailingComments(finalNodes[1])).toEqual([]);
+    expect(leadingComments(finalNodes[2])).toEqual([]);
+    expect(trailingComments(finalNodes[2])).toEqual([]);
+});
+
+test('it does not affect comments after all import declarations', () => {
+    const importNodes = getImportNodes(`
+    import {x} from "c";
+    import {y} from "b";
+    import {z} from "a";
+    // comment final 1
+    // comment final 2
+    `);
+    expect(importNodes).toHaveLength(3);
+    const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
+    adjustCommentsOnSortedNodes(importNodes, finalNodes);
+    expect(finalNodes).toHaveLength(3);
+    expect(leadingComments(finalNodes[0])).toEqual([]);
+    expect(trailingComments(finalNodes[0])).toEqual([]);
+    expect(leadingComments(finalNodes[1])).toEqual([]);
+    expect(trailingComments(finalNodes[1])).toEqual([]);
+    expect(leadingComments(finalNodes[2])).toEqual([]);
+    expect(trailingComments(finalNodes[2])).toEqual([]);
+});

--- a/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
@@ -1,0 +1,285 @@
+import { ImportDeclaration } from '@babel/types';
+
+import { getImportNodes } from '../get-import-nodes';
+import { getSortedNodesByImportOrder } from '../get-sorted-nodes-by-import-order';
+import { getSortedNodesModulesNames } from '../get-sorted-nodes-modules-names';
+import { getSortedNodesNames } from '../get-sorted-nodes-names';
+
+const code = `// first comment
+// second comment
+import z from 'z';
+import c, { cD } from 'c';
+import g from 'g';
+import { tC, tA, tB } from 't';
+import k, { kE, kB } from 'k';
+import * as a from 'a';
+import BY from 'BY';
+import Ba from 'Ba';
+import XY from 'XY';
+import Xa from 'Xa';
+`;
+
+test('it returns all sorted nodes', () => {
+    const result = getImportNodes(code);
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: [],
+        importOrderCaseInsensitive: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
+    }) as ImportDeclaration[];
+
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'BY',
+        'Ba',
+        'XY',
+        'Xa',
+        'a',
+        'c',
+        'g',
+        'k',
+        't',
+        'z',
+    ]);
+    expect(
+        sorted
+            .filter((node) => node.type === 'ImportDeclaration')
+            .map((importDeclaration) =>
+                getSortedNodesModulesNames(importDeclaration.specifiers),
+            ),
+    ).toEqual([
+        ['BY'],
+        ['Ba'],
+        ['XY'],
+        ['Xa'],
+        ['a'],
+        ['c', 'cD'],
+        ['g'],
+        ['k', 'kE', 'kB'],
+        ['tC', 'tA', 'tB'],
+        ['z'],
+    ]);
+});
+
+test('it returns all sorted nodes case-insensitive', () => {
+    const result = getImportNodes(code);
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: [],
+        importOrderCaseInsensitive: true,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
+    }) as ImportDeclaration[];
+
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'a',
+        'Ba',
+        'BY',
+        'c',
+        'g',
+        'k',
+        't',
+        'Xa',
+        'XY',
+        'z',
+    ]);
+    expect(
+        sorted
+            .filter((node) => node.type === 'ImportDeclaration')
+            .map((importDeclaration) =>
+                getSortedNodesModulesNames(importDeclaration.specifiers),
+            ),
+    ).toEqual([
+        ['a'],
+        ['Ba'],
+        ['BY'],
+        ['c', 'cD'],
+        ['g'],
+        ['k', 'kE', 'kB'],
+        ['tC', 'tA', 'tB'],
+        ['Xa'],
+        ['XY'],
+        ['z'],
+    ]);
+});
+
+test('it returns all sorted nodes with sort order', () => {
+    const result = getImportNodes(code);
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^a$', '^t$', '^k$', '^B'],
+        importOrderCaseInsensitive: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
+    }) as ImportDeclaration[];
+
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'XY',
+        'Xa',
+        'c',
+        'g',
+        'z',
+        'a',
+        't',
+        'k',
+        'BY',
+        'Ba',
+    ]);
+    expect(
+        sorted
+            .filter((node) => node.type === 'ImportDeclaration')
+            .map((importDeclaration) =>
+                getSortedNodesModulesNames(importDeclaration.specifiers),
+            ),
+    ).toEqual([
+        ['XY'],
+        ['Xa'],
+        ['c', 'cD'],
+        ['g'],
+        ['z'],
+        ['a'],
+        ['tC', 'tA', 'tB'],
+        ['k', 'kE', 'kB'],
+        ['BY'],
+        ['Ba'],
+    ]);
+});
+
+test('it returns all sorted nodes with sort order case-insensitive', () => {
+    const result = getImportNodes(code);
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^a$', '^t$', '^k$', '^B'],
+        importOrderCaseInsensitive: true,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
+    }) as ImportDeclaration[];
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'c',
+        'g',
+        'Xa',
+        'XY',
+        'z',
+        'a',
+        't',
+        'k',
+        'Ba',
+        'BY',
+    ]);
+    expect(
+        sorted
+            .filter((node) => node.type === 'ImportDeclaration')
+            .map((importDeclaration) =>
+                getSortedNodesModulesNames(importDeclaration.specifiers),
+            ),
+    ).toEqual([
+        ['c', 'cD'],
+        ['g'],
+        ['Xa'],
+        ['XY'],
+        ['z'],
+        ['a'],
+        ['tC', 'tA', 'tB'],
+        ['k', 'kE', 'kB'],
+        ['Ba'],
+        ['BY'],
+    ]);
+});
+
+test('it returns all sorted import nodes with sorted import specifiers', () => {
+    const result = getImportNodes(code);
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^a$', '^t$', '^k$', '^B'],
+        importOrderCaseInsensitive: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: true,
+    }) as ImportDeclaration[];
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'XY',
+        'Xa',
+        'c',
+        'g',
+        'z',
+        'a',
+        't',
+        'k',
+        'BY',
+        'Ba',
+    ]);
+    expect(
+        sorted
+            .filter((node) => node.type === 'ImportDeclaration')
+            .map((importDeclaration) =>
+                getSortedNodesModulesNames(importDeclaration.specifiers),
+            ),
+    ).toEqual([
+        ['XY'],
+        ['Xa'],
+        ['c', 'cD'],
+        ['g'],
+        ['z'],
+        ['a'],
+        ['tA', 'tB', 'tC'],
+        ['k', 'kB', 'kE'],
+        ['BY'],
+        ['Ba'],
+    ]);
+});
+
+test('it returns all sorted import nodes with sorted import specifiers with case-insensitive ', () => {
+    const result = getImportNodes(code);
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^a$', '^t$', '^k$', '^B'],
+        importOrderCaseInsensitive: true,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: true,
+    }) as ImportDeclaration[];
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'c',
+        'g',
+        'Xa',
+        'XY',
+        'z',
+        'a',
+        't',
+        'k',
+        'Ba',
+        'BY',
+    ]);
+    expect(
+        sorted
+            .filter((node) => node.type === 'ImportDeclaration')
+            .map((importDeclaration) =>
+                getSortedNodesModulesNames(importDeclaration.specifiers),
+            ),
+    ).toEqual([
+        ['c', 'cD'],
+        ['g'],
+        ['Xa'],
+        ['XY'],
+        ['z'],
+        ['a'],
+        ['tA', 'tB', 'tC'],
+        ['k', 'kB', 'kE'],
+        ['Ba'],
+        ['BY'],
+    ]);
+});
+
+test('it returns all sorted nodes with custom third party modules', () => {
+    const result = getImportNodes(code);
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$'],
+        importOrderSeparation: false,
+        importOrderCaseInsensitive: true,
+        importOrderSortSpecifiers: false,
+    }) as ImportDeclaration[];
+    expect(getSortedNodesNames(sorted)).toEqual([
+        'a',
+        'Ba',
+        'BY',
+        'c',
+        'g',
+        'Xa',
+        'XY',
+        'z',
+        't',
+        'k',
+    ]);
+});

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -7,19 +7,23 @@ import { getSortedNodesNames } from '../get-sorted-nodes-names';
 
 const code = `// first comment
 // second comment
+import "se3";
 import z from 'z';
 import c, { cD } from 'c';
 import g from 'g';
 import { tC, tA, tB } from 't';
 import k, { kE, kB } from 'k';
+import "se4";
+import "se1";
 import * as a from 'a';
 import BY from 'BY';
 import Ba from 'Ba';
 import XY from 'XY';
 import Xa from 'Xa';
+import "se2";
 `;
 
-test('it returns all sorted nodes', () => {
+test('it returns all sorted nodes, preserving the order side effect nodes', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodes(result, {
         importOrder: [],
@@ -29,16 +33,20 @@ test('it returns all sorted nodes', () => {
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNames(sorted)).toEqual([
-        'BY',
-        'Ba',
-        'XY',
-        'Xa',
-        'a',
+        "se3",
         'c',
         'g',
         'k',
         't',
         'z',
+        "se4",
+        "se1",
+        'BY',
+        'Ba',
+        'XY',
+        'Xa',
+        'a',
+        "se2",
     ]);
     expect(
         sorted
@@ -47,239 +55,20 @@ test('it returns all sorted nodes', () => {
                 getSortedNodesModulesNames(importDeclaration.specifiers),
             ),
     ).toEqual([
-        ['BY'],
-        ['Ba'],
-        ['XY'],
-        ['Xa'],
-        ['a'],
+        [],
         ['c', 'cD'],
         ['g'],
         ['k', 'kE', 'kB'],
         ['tC', 'tA', 'tB'],
         ['z'],
-    ]);
-});
-
-test('it returns all sorted nodes case-insensitive', () => {
-    const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: [],
-        importOrderCaseInsensitive: true,
-        importOrderSeparation: false,
-        importOrderSortSpecifiers: false,
-    }) as ImportDeclaration[];
-
-    expect(getSortedNodesNames(sorted)).toEqual([
-        'a',
-        'Ba',
-        'BY',
-        'c',
-        'g',
-        'k',
-        't',
-        'Xa',
-        'XY',
-        'z',
-    ]);
-    expect(
-        sorted
-            .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) =>
-                getSortedNodesModulesNames(importDeclaration.specifiers),
-            ),
-    ).toEqual([
-        ['a'],
-        ['Ba'],
-        ['BY'],
-        ['c', 'cD'],
-        ['g'],
-        ['k', 'kE', 'kB'],
-        ['tC', 'tA', 'tB'],
-        ['Xa'],
-        ['XY'],
-        ['z'],
-    ]);
-});
-
-test('it returns all sorted nodes with sort order', () => {
-    const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: ['^a$', '^t$', '^k$', '^B'],
-        importOrderCaseInsensitive: false,
-        importOrderSeparation: false,
-        importOrderSortSpecifiers: false,
-    }) as ImportDeclaration[];
-
-    expect(getSortedNodesNames(sorted)).toEqual([
-        'XY',
-        'Xa',
-        'c',
-        'g',
-        'z',
-        'a',
-        't',
-        'k',
-        'BY',
-        'Ba',
-    ]);
-    expect(
-        sorted
-            .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) =>
-                getSortedNodesModulesNames(importDeclaration.specifiers),
-            ),
-    ).toEqual([
-        ['XY'],
-        ['Xa'],
-        ['c', 'cD'],
-        ['g'],
-        ['z'],
-        ['a'],
-        ['tC', 'tA', 'tB'],
-        ['k', 'kE', 'kB'],
+        [],
+        [],
         ['BY'],
         ['Ba'],
-    ]);
-});
-
-test('it returns all sorted nodes with sort order case-insensitive', () => {
-    const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: ['^a$', '^t$', '^k$', '^B'],
-        importOrderCaseInsensitive: true,
-        importOrderSeparation: false,
-        importOrderSortSpecifiers: false,
-    }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual([
-        'c',
-        'g',
-        'Xa',
-        'XY',
-        'z',
-        'a',
-        't',
-        'k',
-        'Ba',
-        'BY',
-    ]);
-    expect(
-        sorted
-            .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) =>
-                getSortedNodesModulesNames(importDeclaration.specifiers),
-            ),
-    ).toEqual([
-        ['c', 'cD'],
-        ['g'],
-        ['Xa'],
-        ['XY'],
-        ['z'],
-        ['a'],
-        ['tC', 'tA', 'tB'],
-        ['k', 'kE', 'kB'],
-        ['Ba'],
-        ['BY'],
-    ]);
-});
-
-test('it returns all sorted import nodes with sorted import specifiers', () => {
-    const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: ['^a$', '^t$', '^k$', '^B'],
-        importOrderCaseInsensitive: false,
-        importOrderSeparation: false,
-        importOrderSortSpecifiers: true,
-    }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual([
-        'XY',
-        'Xa',
-        'c',
-        'g',
-        'z',
-        'a',
-        't',
-        'k',
-        'BY',
-        'Ba',
-    ]);
-    expect(
-        sorted
-            .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) =>
-                getSortedNodesModulesNames(importDeclaration.specifiers),
-            ),
-    ).toEqual([
         ['XY'],
         ['Xa'],
-        ['c', 'cD'],
-        ['g'],
-        ['z'],
         ['a'],
-        ['tA', 'tB', 'tC'],
-        ['k', 'kB', 'kE'],
-        ['BY'],
-        ['Ba'],
+        [],
     ]);
 });
 
-test('it returns all sorted import nodes with sorted import specifiers with case-insensitive ', () => {
-    const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: ['^a$', '^t$', '^k$', '^B'],
-        importOrderCaseInsensitive: true,
-        importOrderSeparation: false,
-        importOrderSortSpecifiers: true,
-    }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual([
-        'c',
-        'g',
-        'Xa',
-        'XY',
-        'z',
-        'a',
-        't',
-        'k',
-        'Ba',
-        'BY',
-    ]);
-    expect(
-        sorted
-            .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) =>
-                getSortedNodesModulesNames(importDeclaration.specifiers),
-            ),
-    ).toEqual([
-        ['c', 'cD'],
-        ['g'],
-        ['Xa'],
-        ['XY'],
-        ['z'],
-        ['a'],
-        ['tA', 'tB', 'tC'],
-        ['k', 'kB', 'kE'],
-        ['Ba'],
-        ['BY'],
-    ]);
-});
-
-test('it returns all sorted nodes with custom third party modules', () => {
-    const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$'],
-        importOrderSeparation: false,
-        importOrderCaseInsensitive: true,
-        importOrderSortSpecifiers: false,
-    }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual([
-        'a',
-        'Ba',
-        'BY',
-        'c',
-        'g',
-        'Xa',
-        'XY',
-        'z',
-        't',
-        'k',
-    ]);
-});

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -33,20 +33,20 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNames(sorted)).toEqual([
-        "se3",
+        'se3',
         'c',
         'g',
         'k',
         't',
         'z',
-        "se4",
-        "se1",
+        'se4',
+        'se1',
         'BY',
         'Ba',
         'XY',
         'Xa',
         'a',
-        "se2",
+        'se2',
     ]);
     expect(
         sorted
@@ -71,4 +71,3 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
         [],
     ]);
 });
-

--- a/src/utils/adjust-comments-on-sorted-nodes.ts
+++ b/src/utils/adjust-comments-on-sorted-nodes.ts
@@ -1,18 +1,18 @@
-import { addComments, ImportDeclaration, removeComments } from '@babel/types';
+import { ImportDeclaration, addComments, removeComments } from '@babel/types';
 import { clone, isEqual } from 'lodash';
 
-import { ImportOrLine } from "../types";
+import { ImportOrLine } from '../types';
 
 /**
  * Takes the original nodes before sorting and the final nodes after sorting.
  * Adjusts the comments on the final nodes so that they match the comments as
- * they were in the original nodes. 
+ * they were in the original nodes.
  * @param nodes A list of nodes in the order as they were originally.
  * @param finalNodes The same set of nodes, but in the final sorting order.
  */
 export const adjustCommentsOnSortedNodes = (
     nodes: ImportDeclaration[],
-    finalNodes: ImportOrLine[]
+    finalNodes: ImportOrLine[],
 ) => {
     // maintain a copy of the nodes to extract comments from
     const finalNodesClone = finalNodes.map(clone);
@@ -36,4 +36,4 @@ export const adjustCommentsOnSortedNodes = (
     if (firstNodesComments) {
         addComments(finalNodes[0], 'leading', firstNodesComments);
     }
-}
+};

--- a/src/utils/adjust-comments-on-sorted-nodes.ts
+++ b/src/utils/adjust-comments-on-sorted-nodes.ts
@@ -1,0 +1,39 @@
+import { addComments, ImportDeclaration, removeComments } from '@babel/types';
+import { clone, isEqual } from 'lodash';
+
+import { ImportOrLine } from "../types";
+
+/**
+ * Takes the original nodes before sorting and the final nodes after sorting.
+ * Adjusts the comments on the final nodes so that they match the comments as
+ * they were in the original nodes. 
+ * @param nodes A list of nodes in the order as they were originally.
+ * @param finalNodes The same set of nodes, but in the final sorting order.
+ */
+export const adjustCommentsOnSortedNodes = (
+    nodes: ImportDeclaration[],
+    finalNodes: ImportOrLine[]
+) => {
+    // maintain a copy of the nodes to extract comments from
+    const finalNodesClone = finalNodes.map(clone);
+
+    const firstNodesComments = nodes[0].leadingComments;
+
+    // Remove all comments from sorted nodes
+    finalNodes.forEach(removeComments);
+
+    // insert comments other than the first comments
+    finalNodes.forEach((node, index) => {
+        if (isEqual(nodes[0].loc, node.loc)) return;
+
+        addComments(
+            node,
+            'leading',
+            finalNodesClone[index].leadingComments || [],
+        );
+    });
+
+    if (firstNodesComments) {
+        addComments(finalNodes[0], 'leading', firstNodesComments);
+    }
+}

--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -46,7 +46,8 @@ export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
         importOrderGroups[matchedGroup].push(node);
     }
 
-    for (const group of importOrder) {
+    for (let i = 0; i < importOrder.length; i += 1) {
+        const group = importOrder[i];
         const groupNodes = importOrderGroups[group];
         const last = group === importOrder[importOrder.length - 1];
 

--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -49,7 +49,6 @@ export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
     for (let i = 0; i < importOrder.length; i += 1) {
         const group = importOrder[i];
         const groupNodes = importOrderGroups[group];
-        const last = group === importOrder[importOrder.length - 1];
 
         if (groupNodes.length === 0) continue;
 
@@ -66,7 +65,8 @@ export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
 
         finalNodes.push(...sortedInsideGroup);
 
-        if (importOrderSeparation && !last) {
+        // Do not add a new line after the last group of nodes
+        if (importOrderSeparation && i < importOrder.length - 1) {
             finalNodes.push(newLineNode);
         }
     }

--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -1,0 +1,74 @@
+import { clone } from 'lodash';
+
+import { THIRD_PARTY_MODULES_SPECIAL_WORD, newLineNode } from '../constants';
+import { naturalSort } from '../natural-sort';
+import { GetSortedNodes, ImportGroups, ImportOrLine } from '../types';
+import { getImportNodesMatchedGroup } from './get-import-nodes-matched-group';
+import { getSortedImportSpecifiers } from './get-sorted-import-specifiers';
+
+/**
+ * This function returns the given nodes, sorted in the order as indicated by
+ * the importOrder array from the given options.
+ * The plugin considers these import nodes as local import declarations.
+ * @param nodes A subset of all import nodes that should be sorted.
+ * @param options Options to influence the behavior of the sorting algorithm.
+ */
+export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
+    naturalSort.insensitive = options.importOrderCaseInsensitive;
+
+    let { importOrder } = options;
+    const { importOrderSeparation, importOrderSortSpecifiers } = options;
+
+    const originalNodes = nodes.map(clone);
+    const finalNodes: ImportOrLine[] = [];
+
+    if (!importOrder.includes(THIRD_PARTY_MODULES_SPECIAL_WORD)) {
+        importOrder = [THIRD_PARTY_MODULES_SPECIAL_WORD, ...importOrder];
+    }
+
+    const importOrderGroups = importOrder.reduce<ImportGroups>(
+        (groups, regexp) => ({
+            ...groups,
+            [regexp]: [],
+        }),
+        {},
+    );
+
+    const importOrderWithOutThirdPartyPlaceholder = importOrder.filter(
+        (group) => group !== THIRD_PARTY_MODULES_SPECIAL_WORD,
+    );
+
+    for (const node of originalNodes) {
+        const matchedGroup = getImportNodesMatchedGroup(
+            node,
+            importOrderWithOutThirdPartyPlaceholder,
+        );
+        importOrderGroups[matchedGroup].push(node);
+    }
+
+    for (const group of importOrder) {
+        const groupNodes = importOrderGroups[group];
+        const last = group === importOrder[importOrder.length - 1];
+
+        if (groupNodes.length === 0) continue;
+
+        const sortedInsideGroup = groupNodes.sort((a, b) =>
+            naturalSort(a.source.value, b.source.value),
+        );
+
+        // Sort the import specifiers
+        if (importOrderSortSpecifiers) {
+            sortedInsideGroup.forEach((node) =>
+                getSortedImportSpecifiers(node),
+            );
+        }
+
+        finalNodes.push(...sortedInsideGroup);
+
+        if (importOrderSeparation && !last) {
+            finalNodes.push(newLineNode);
+        }
+    }
+
+    return finalNodes;
+};

--- a/src/utils/get-sorted-nodes.ts
+++ b/src/utils/get-sorted-nodes.ts
@@ -1,13 +1,17 @@
-import { ChunkSideEffectNode, ChunkSideOtherNode, newLineNode } from "../constants";
-import { GetSortedNodes, ImportChunk, ImportOrLine } from "../types";
-import { adjustCommentsOnSortedNodes } from "./adjust-comments-on-sorted-nodes";
-import { getSortedNodesByImportOrder } from "./get-sorted-nodes-by-import-order";
+import {
+    ChunkSideEffectNode,
+    ChunkSideOtherNode,
+    newLineNode,
+} from '../constants';
+import { GetSortedNodes, ImportChunk, ImportOrLine } from '../types';
+import { adjustCommentsOnSortedNodes } from './adjust-comments-on-sorted-nodes';
+import { getSortedNodesByImportOrder } from './get-sorted-nodes-by-import-order';
 
 /**
  * This function returns the given nodes, sorted in the order as indicated by
  * the importOrder array. The plugin considers these import nodes as local
  * import declarations
- * 
+ *
  * In addition, this method preserves the relative order of side effect imports
  * and non side effect imports. A side effect import is an ImportDeclaration
  * without any import specifiers. It does this by splitting the import nodes at
@@ -21,20 +25,22 @@ export const getSortedNodes: GetSortedNodes = (nodes, options) => {
 
     // Split nodes at each boundary between a side-effect node and a
     // non-side-effect node, keeping both types of nodes together.
-    const splitBySideEffectNodes =
-        nodes.reduce<ImportChunk[]>((chunks, node) => {
-            const type = node.specifiers.length === 0
-                ? ChunkSideEffectNode
-                : ChunkSideOtherNode;
+    const splitBySideEffectNodes = nodes.reduce<ImportChunk[]>(
+        (chunks, node) => {
+            const type =
+                node.specifiers.length === 0
+                    ? ChunkSideEffectNode
+                    : ChunkSideOtherNode;
             const last = chunks[chunks.length - 1];
             if (last === undefined || last.type !== type) {
                 chunks.push({ type, nodes: [node] });
-            }
-            else {
+            } else {
                 last.nodes.push(node);
             }
             return chunks;
-        }, []);
+        },
+        [],
+    );
 
     const finalNodes: ImportOrLine[] = [];
 
@@ -44,8 +50,7 @@ export const getSortedNodes: GetSortedNodes = (nodes, options) => {
         if (chunk.type === ChunkSideEffectNode) {
             // do not sort side effect nodes
             finalNodes.push(...chunk.nodes);
-        }
-        else {
+        } else {
             // sort non-side effect nodes
             const sorted = getSortedNodesByImportOrder(chunk.nodes, options);
             finalNodes.push(...sorted);
@@ -63,4 +68,4 @@ export const getSortedNodes: GetSortedNodes = (nodes, options) => {
     adjustCommentsOnSortedNodes(nodes, finalNodes);
 
     return finalNodes;
-}
+};

--- a/src/utils/get-sorted-nodes.ts
+++ b/src/utils/get-sorted-nodes.ts
@@ -1,101 +1,66 @@
-import { addComments, removeComments } from '@babel/types';
-import { clone, isEqual } from 'lodash';
-
-import { THIRD_PARTY_MODULES_SPECIAL_WORD, newLineNode } from '../constants';
-import { naturalSort } from '../natural-sort';
-import { GetSortedNodes, ImportGroups, ImportOrLine } from '../types';
-import { getImportNodesMatchedGroup } from './get-import-nodes-matched-group';
-import { getSortedImportSpecifiers } from './get-sorted-import-specifiers';
+import { ChunkSideEffectNode, ChunkSideOtherNode, newLineNode } from "../constants";
+import { GetSortedNodes, ImportChunk, ImportOrLine } from "../types";
+import { adjustCommentsOnSortedNodes } from "./adjust-comments-on-sorted-nodes";
+import { getSortedNodesByImportOrder } from "./get-sorted-nodes-by-import-order";
 
 /**
- * This function returns all the nodes which are in the importOrder array.
- * The plugin considered these import nodes as local import declarations.
- * @param nodes all import nodes
- * @param options
+ * This function returns the given nodes, sorted in the order as indicated by
+ * the importOrder array. The plugin considers these import nodes as local
+ * import declarations
+ * 
+ * In addition, this method preserves the relative order of side effect imports
+ * and non side effect imports. A side effect import is an ImportDeclaration
+ * without any import specifiers. It does this by splitting the import nodes at
+ * each side effect node, then sorting only the non side effect import nodes
+ * between the side effect nodes according to the given options.
+ * @param nodes All import nodes that should be sorted.
+ * @param options Options to influence the behavior of the sorting algorithm.
  */
 export const getSortedNodes: GetSortedNodes = (nodes, options) => {
-    naturalSort.insensitive = options.importOrderCaseInsensitive;
+    const { importOrderSeparation } = options;
 
-    let { importOrder } = options;
-    const { importOrderSeparation, importOrderSortSpecifiers } = options;
+    // Split nodes at each boundary between a side-effect node and a
+    // non-side-effect node, keeping both types of nodes together.
+    const splitBySideEffectNodes =
+        nodes.reduce<ImportChunk[]>((chunks, node) => {
+            const type = node.specifiers.length === 0
+                ? ChunkSideEffectNode
+                : ChunkSideOtherNode;
+            const last = chunks[chunks.length - 1];
+            if (last === undefined || last.type !== type) {
+                chunks.push({ type, nodes: [node] });
+            }
+            else {
+                last.nodes.push(node);
+            }
+            return chunks;
+        }, []);
 
-    const originalNodes = nodes.map(clone);
     const finalNodes: ImportOrLine[] = [];
 
-    if (!importOrder.includes(THIRD_PARTY_MODULES_SPECIAL_WORD)) {
-        importOrder = [THIRD_PARTY_MODULES_SPECIAL_WORD, ...importOrder];
-    }
-
-    const importOrderGroups = importOrder.reduce<ImportGroups>(
-        (groups, regexp) => ({
-            ...groups,
-            [regexp]: [],
-        }),
-        {},
-    );
-
-    const importOrderWithOutThirdPartyPlaceholder = importOrder.filter(
-        (group) => group !== THIRD_PARTY_MODULES_SPECIAL_WORD,
-    );
-
-    for (const node of originalNodes) {
-        const matchedGroup = getImportNodesMatchedGroup(
-            node,
-            importOrderWithOutThirdPartyPlaceholder,
-        );
-        importOrderGroups[matchedGroup].push(node);
-    }
-
-    for (const group of importOrder) {
-        const groupNodes = importOrderGroups[group];
-
-        if (groupNodes.length === 0) continue;
-
-        const sortedInsideGroup = groupNodes.sort((a, b) =>
-            naturalSort(a.source.value, b.source.value),
-        );
-
-        // Sort the import specifiers
-        if (importOrderSortSpecifiers) {
-            sortedInsideGroup.forEach((node) =>
-                getSortedImportSpecifiers(node),
-            );
+    // Sort each chunk of side-effect and non-side-effect nodes, and insert new
+    // lines according the importOrderSeparation option.
+    for (const chunk of splitBySideEffectNodes) {
+        if (chunk.type === ChunkSideEffectNode) {
+            // do not sort side effect nodes
+            finalNodes.push(...chunk.nodes);
         }
-
-        finalNodes.push(...sortedInsideGroup);
-
+        else {
+            // sort non-side effect nodes
+            const sorted = getSortedNodesByImportOrder(chunk.nodes, options);
+            finalNodes.push(...sorted);
+        }
         if (importOrderSeparation) {
             finalNodes.push(newLineNode);
         }
     }
 
     if (finalNodes.length > 0 && !importOrderSeparation) {
-        // a newline after all imports
         finalNodes.push(newLineNode);
     }
 
-    // maintain a copy of the nodes to extract comments from
-    const finalNodesClone = finalNodes.map(clone);
-
-    const firstNodesComments = nodes[0].leadingComments;
-
-    // Remove all comments from sorted nodes
-    finalNodes.forEach(removeComments);
-
-    // insert comments other than the first comments
-    finalNodes.forEach((node, index) => {
-        if (isEqual(nodes[0].loc, node.loc)) return;
-
-        addComments(
-            node,
-            'leading',
-            finalNodesClone[index].leadingComments || [],
-        );
-    });
-
-    if (firstNodesComments) {
-        addComments(finalNodes[0], 'leading', firstNodesComments);
-    }
+    // Adjust the comments on the sorted nodes to match the original comments
+    adjustCommentsOnSortedNodes(nodes, finalNodes);
 
     return finalNodes;
-};
+}

--- a/src/utils/get-sorted-nodes.ts
+++ b/src/utils/get-sorted-nodes.ts
@@ -1,6 +1,6 @@
 import {
-    ChunkSideEffectNode,
-    ChunkSideOtherNode,
+    chunkSideEffectNode,
+    chunkSideOtherNode,
     newLineNode,
 } from '../constants';
 import { GetSortedNodes, ImportChunk, ImportOrLine } from '../types';
@@ -29,8 +29,8 @@ export const getSortedNodes: GetSortedNodes = (nodes, options) => {
         (chunks, node) => {
             const type =
                 node.specifiers.length === 0
-                    ? ChunkSideEffectNode
-                    : ChunkSideOtherNode;
+                    ? chunkSideEffectNode
+                    : chunkSideOtherNode;
             const last = chunks[chunks.length - 1];
             if (last === undefined || last.type !== type) {
                 chunks.push({ type, nodes: [node] });
@@ -47,7 +47,7 @@ export const getSortedNodes: GetSortedNodes = (nodes, options) => {
     // Sort each chunk of side-effect and non-side-effect nodes, and insert new
     // lines according the importOrderSeparation option.
     for (const chunk of splitBySideEffectNodes) {
-        if (chunk.type === ChunkSideEffectNode) {
+        if (chunk.type === chunkSideEffectNode) {
             // do not sort side effect nodes
             finalNodes.push(...chunk.nodes);
         } else {

--- a/tests/Angular/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Angular/__snapshots__/ppsi.spec.js.snap
@@ -99,7 +99,9 @@ import thirdParty1 from "third-party1";
 import oneLevelRelativePath1 from "../oneLevelRelativePath1";
 import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
 
-import "side-effect-y";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
 
 import oneLevelRelativePath2 from "../oneLevelRelativePath2";
 import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
@@ -168,7 +170,9 @@ import oneLevelRelativePath1 from "../oneLevelRelativePath1";
 import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
 import sameLevelRelativePath3 from "./sameLevelRelativePath3";
 
-import "side-effect-y";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
 
 import thirdDisco3 from "third-disco3";
 import thirdParty3 from "third-party3";

--- a/tests/Angular/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Angular/__snapshots__/ppsi.spec.js.snap
@@ -80,3 +80,146 @@ export class TemplateController {
 }
 
 `;
+
+exports[`imports-with-side-effect-imports.js - typescript-verify: imports-with-side-effect-imports.js 1`] = `
+// I am top level comment in this file.
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+
+import "side-effect-z";
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+import thirdDisco1 from "third-disco1";
+import otherthing0 from "@core/otherthing0";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import thirdParty1 from "third-party1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+
+import "side-effect-y";
+
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import something2 from "@core/something2";
+import thirdParty3 from "third-party3";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import otherthing2 from "@core/otherthing2";
+import thirdDisco3 from "third-disco3";
+
+import "side-effect-x";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+import something1 from "@core/something1";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import otherthing1 from "@core/otherthing1";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import { Component } from "@angular/core";
+
+@Controller("/design/template")
+export class TemplateController {
+  requestFile: (url) => Promise<ArrayBuffer>;
+  CanvasKit: CanvasKit;
+
+  constructor(private templateService: TemplateService, private _httpService: HttpService,
+              private _canvaskitService: CanvasKitService) {
+
+
+    this.CanvasKit = this._canvaskitService.canvasKit;
+    this.requestFile = (url) => {
+      const req = this._httpService
+        .get<ArrayBuffer>(\`http:\${url}\`, { responseType: "arraybuffer" })
+        .pipe(retry(3))
+        .toPromise();
+      return new Promise<ArrayBuffer>((resolve, reject) => {
+        req
+          .then((resp) => {
+            resolve(resp.data);
+          })
+          .catch(reject);
+      });
+    };
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// I am top level comment in this file.
+import thirdDisco0 from "third-disco0";
+import thirdParty0 from "third-party0";
+
+import otherthing3 from "@core/otherthing3";
+import something3 from "@core/something3";
+
+import "side-effect-z";
+
+import thirdDisco1 from "third-disco1";
+import thirdParty1 from "third-party1";
+
+import otherthing0 from "@core/otherthing0";
+import something0 from "@core/something0";
+
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+
+import "side-effect-y";
+
+import thirdDisco3 from "third-disco3";
+import thirdParty3 from "third-party3";
+
+import otherthing2 from "@core/otherthing2";
+import something2 from "@core/something2";
+
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+
+import "side-effect-x";
+
+import { Component } from "@angular/core";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import otherthing1 from "@core/otherthing1";
+import something1 from "@core/something1";
+
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+
+@Controller("/design/template")
+export class TemplateController {
+    requestFile: (url) => Promise<ArrayBuffer>;
+    CanvasKit: CanvasKit;
+
+    constructor(
+        private templateService: TemplateService,
+        private _httpService: HttpService,
+        private _canvaskitService: CanvasKitService
+    ) {
+        this.CanvasKit = this._canvaskitService.canvasKit;
+        this.requestFile = (url) => {
+            const req = this._httpService
+                .get<ArrayBuffer>(\`http:\${url}\`, {
+                    responseType: "arraybuffer",
+                })
+                .pipe(retry(3))
+                .toPromise();
+            return new Promise<ArrayBuffer>((resolve, reject) => {
+                req.then((resp) => {
+                    resolve(resp.data);
+                }).catch(reject);
+            });
+        };
+    }
+}
+
+`;

--- a/tests/Angular/imports-with-side-effect-imports.js
+++ b/tests/Angular/imports-with-side-effect-imports.js
@@ -1,0 +1,65 @@
+// I am top level comment in this file.
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+
+import "side-effect-z";
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+import thirdDisco1 from "third-disco1";
+import otherthing0 from "@core/otherthing0";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import thirdParty1 from "third-party1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+
+import "side-effect-y";
+
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import something2 from "@core/something2";
+import thirdParty3 from "third-party3";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import otherthing2 from "@core/otherthing2";
+import thirdDisco3 from "third-disco3";
+
+import "side-effect-x";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+import something1 from "@core/something1";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import otherthing1 from "@core/otherthing1";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import { Component } from "@angular/core";
+
+@Controller("/design/template")
+export class TemplateController {
+  requestFile: (url) => Promise<ArrayBuffer>;
+  CanvasKit: CanvasKit;
+
+  constructor(private templateService: TemplateService, private _httpService: HttpService,
+              private _canvaskitService: CanvasKitService) {
+
+
+    this.CanvasKit = this._canvaskitService.canvasKit;
+    this.requestFile = (url) => {
+      const req = this._httpService
+        .get<ArrayBuffer>(`http:${url}`, { responseType: "arraybuffer" })
+        .pipe(retry(3))
+        .toPromise();
+      return new Promise<ArrayBuffer>((resolve, reject) => {
+        req
+          .then((resp) => {
+            resolve(resp.data);
+          })
+          .catch(reject);
+      });
+    };
+  }
+}

--- a/tests/Angular/imports-with-side-effect-imports.js
+++ b/tests/Angular/imports-with-side-effect-imports.js
@@ -15,7 +15,9 @@ import thirdParty1 from "third-party1";
 import oneLevelRelativePath1 from "../oneLevelRelativePath1";
 import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
 
-import "side-effect-y";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
 
 import oneLevelRelativePath2 from "../oneLevelRelativePath2";
 import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";

--- a/tests/Babel/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Babel/__snapshots__/ppsi.spec.js.snap
@@ -42,3 +42,101 @@ function add(a, b) {
 }
 
 `;
+
+exports[`imports-with-side-effect-imports.js - babel-verify: imports-with-side-effect-imports.js 1`] = `
+// I am top level comment in this file.
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+
+import "side-effect-z";
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+import thirdDisco1 from "third-disco1";
+import otherthing0 from "@core/otherthing0";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import thirdParty1 from "third-party1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+
+import "side-effect-y";
+
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import something2 from "@core/something2";
+import thirdParty3 from "third-party3";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import otherthing2 from "@core/otherthing2";
+import thirdDisco3 from "third-disco3";
+
+import "side-effect-x";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+import something1 from "@core/something1";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import otherthing1 from "@core/otherthing1";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import { Component } from "@angular/core";
+
+function add(a,b) {
+  return a + b;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// I am top level comment in this file.
+import thirdDisco0 from "third-disco0";
+import thirdParty0 from "third-party0";
+
+import otherthing3 from "@core/otherthing3";
+import something3 from "@core/something3";
+
+import "side-effect-z";
+
+import thirdDisco1 from "third-disco1";
+import thirdParty1 from "third-party1";
+
+import otherthing0 from "@core/otherthing0";
+import something0 from "@core/something0";
+
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+
+import "side-effect-y";
+
+import thirdDisco3 from "third-disco3";
+import thirdParty3 from "third-party3";
+
+import otherthing2 from "@core/otherthing2";
+import something2 from "@core/something2";
+
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+
+import "side-effect-x";
+
+import { Component } from "@angular/core";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import otherthing1 from "@core/otherthing1";
+import something1 from "@core/something1";
+
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+
+function add(a, b) {
+    return a + b;
+}
+
+`;

--- a/tests/Babel/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Babel/__snapshots__/ppsi.spec.js.snap
@@ -61,7 +61,9 @@ import thirdParty1 from "third-party1";
 import oneLevelRelativePath1 from "../oneLevelRelativePath1";
 import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
 
-import "side-effect-y";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
 
 import oneLevelRelativePath2 from "../oneLevelRelativePath2";
 import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
@@ -108,7 +110,9 @@ import oneLevelRelativePath1 from "../oneLevelRelativePath1";
 import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
 import sameLevelRelativePath3 from "./sameLevelRelativePath3";
 
-import "side-effect-y";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
 
 import thirdDisco3 from "third-disco3";
 import thirdParty3 from "third-party3";

--- a/tests/Babel/imports-with-side-effect-imports.js
+++ b/tests/Babel/imports-with-side-effect-imports.js
@@ -1,0 +1,43 @@
+// I am top level comment in this file.
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+
+import "side-effect-z";
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+import thirdDisco1 from "third-disco1";
+import otherthing0 from "@core/otherthing0";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import thirdParty1 from "third-party1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+
+import "side-effect-y";
+
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import something2 from "@core/something2";
+import thirdParty3 from "third-party3";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import otherthing2 from "@core/otherthing2";
+import thirdDisco3 from "third-disco3";
+
+import "side-effect-x";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+import something1 from "@core/something1";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import otherthing1 from "@core/otherthing1";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import { Component } from "@angular/core";
+
+function add(a,b) {
+  return a + b;
+}

--- a/tests/Babel/imports-with-side-effect-imports.js
+++ b/tests/Babel/imports-with-side-effect-imports.js
@@ -15,7 +15,9 @@ import thirdParty1 from "third-party1";
 import oneLevelRelativePath1 from "../oneLevelRelativePath1";
 import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
 
-import "side-effect-y";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
 
 import oneLevelRelativePath2 from "../oneLevelRelativePath2";
 import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";

--- a/tests/Flow/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Flow/__snapshots__/ppsi.spec.js.snap
@@ -65,3 +65,133 @@ export function givesAFoo3Obj(): AliasFoo3 {
 }
 
 `;
+
+exports[`imports-with-side-effect-imports.js - flow-verify: imports-with-side-effect-imports.js 1`] = `
+/**
+ * @flow
+ */
+
+// I am top level comment in this file.
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+import { type Something2 } from './__generated2__/';
+
+import "side-effect-z";
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+import thirdDisco1 from "third-disco1";
+import { type Something3 } from './__generated3__/';
+import otherthing0 from "@core/otherthing0";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import thirdParty1 from "third-party1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+
+import "side-effect-y";
+
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import something2 from "@core/something2";
+import thirdParty3 from "third-party3";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import otherthing2 from "@core/otherthing2";
+import { type Something1 } from './__generated1__/';
+import thirdDisco3 from "third-disco3";
+
+import "side-effect-x";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+import something1 from "@core/something1";
+import { type Something0 } from './__generated0__/';
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import otherthing1 from "@core/otherthing1";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import { Component } from "@angular/core";
+
+const handleChange = (value: ?string) => {}
+
+export type AliasFoo3  = {
+  givesANum(): number
+};
+export function givesAFoo3Obj(): AliasFoo3 {
+  return {
+    givesANum(): number { return 42; }
+  };
+};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/**
+ * @flow
+ */
+// I am top level comment in this file.
+import thirdDisco0 from "third-disco0";
+import thirdParty0 from "third-party0";
+
+import otherthing3 from "@core/otherthing3";
+import something3 from "@core/something3";
+
+import { type Something2 } from "./__generated2__/";
+
+import "side-effect-z";
+
+import thirdDisco1 from "third-disco1";
+import thirdParty1 from "third-party1";
+
+import otherthing0 from "@core/otherthing0";
+import something0 from "@core/something0";
+
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import { type Something3 } from "./__generated3__/";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+
+import "side-effect-y";
+
+import thirdDisco3 from "third-disco3";
+import thirdParty3 from "third-party3";
+
+import otherthing2 from "@core/otherthing2";
+import something2 from "@core/something2";
+
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import { type Something1 } from "./__generated1__/";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+
+import "side-effect-x";
+
+import { Component } from "@angular/core";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import otherthing1 from "@core/otherthing1";
+import something1 from "@core/something1";
+
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import { type Something0 } from "./__generated0__/";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+
+const handleChange = (value: ?string) => {};
+
+export type AliasFoo3 = {
+    givesANum(): number,
+};
+export function givesAFoo3Obj(): AliasFoo3 {
+    return {
+        givesANum(): number {
+            return 42;
+        },
+    };
+}
+
+`;

--- a/tests/Flow/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Flow/__snapshots__/ppsi.spec.js.snap
@@ -90,7 +90,9 @@ import thirdParty1 from "third-party1";
 import oneLevelRelativePath1 from "../oneLevelRelativePath1";
 import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
 
-import "side-effect-y";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
 
 import oneLevelRelativePath2 from "../oneLevelRelativePath2";
 import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
@@ -152,7 +154,9 @@ import { type Something3 } from "./__generated3__/";
 import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
 import sameLevelRelativePath3 from "./sameLevelRelativePath3";
 
-import "side-effect-y";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
 
 import thirdDisco3 from "third-disco3";
 import thirdParty3 from "third-party3";

--- a/tests/Flow/imports-with-side-effect-imports.js
+++ b/tests/Flow/imports-with-side-effect-imports.js
@@ -21,7 +21,9 @@ import thirdParty1 from "third-party1";
 import oneLevelRelativePath1 from "../oneLevelRelativePath1";
 import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
 
-import "side-effect-y";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
 
 import oneLevelRelativePath2 from "../oneLevelRelativePath2";
 import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";

--- a/tests/Flow/imports-with-side-effect-imports.js
+++ b/tests/Flow/imports-with-side-effect-imports.js
@@ -1,0 +1,58 @@
+/**
+ * @flow
+ */
+
+// I am top level comment in this file.
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+import { type Something2 } from './__generated2__/';
+
+import "side-effect-z";
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+import thirdDisco1 from "third-disco1";
+import { type Something3 } from './__generated3__/';
+import otherthing0 from "@core/otherthing0";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import thirdParty1 from "third-party1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+
+import "side-effect-y";
+
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import something2 from "@core/something2";
+import thirdParty3 from "third-party3";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import otherthing2 from "@core/otherthing2";
+import { type Something1 } from './__generated1__/';
+import thirdDisco3 from "third-disco3";
+
+import "side-effect-x";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+import something1 from "@core/something1";
+import { type Something0 } from './__generated0__/';
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import otherthing1 from "@core/otherthing1";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import { Component } from "@angular/core";
+
+const handleChange = (value: ?string) => {}
+
+export type AliasFoo3  = {
+  givesANum(): number
+};
+export function givesAFoo3Obj(): AliasFoo3 {
+  return {
+    givesANum(): number { return 42; }
+  };
+};

--- a/tests/ImportsNotSeparated/__snapshots__/ppsi.spec.js.snap
+++ b/tests/ImportsNotSeparated/__snapshots__/ppsi.spec.js.snap
@@ -96,8 +96,8 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
-import React from "react";
 import "./commands";
+import React from "react";
 
 // Comment
 // Comment

--- a/tests/ImportsNotSeparatedRest/__snapshots__/ppsi.spec.js.snap
+++ b/tests/ImportsNotSeparatedRest/__snapshots__/ppsi.spec.js.snap
@@ -96,8 +96,8 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
-import React from "react";
 import "./commands";
+import React from "react";
 
 // Comment
 // Comment

--- a/tests/ImportsSeparated/__snapshots__/ppsi.spec.js.snap
+++ b/tests/ImportsSeparated/__snapshots__/ppsi.spec.js.snap
@@ -1,6 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`import-export-in-between.ts - typescript-verify: import-export-in-between.ts 1`] = `
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+export { random } from './random';
+import c from 'c';
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import a from 'a';
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import component from "@ui/hello";
+export default {
+    title: 'hello',
+};
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import something from "@server/something";
+import x from 'x';
+
+function add(a:number,b:number) {
+  return a + b;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import a from "a";
+import c from "c";
+import thirdParty from "third-party";
+import x from "x";
+
+import otherthing from "@core/otherthing";
+
+import something from "@server/something";
+
+import component from "@ui/hello";
+
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+
+export { random } from "./random";
+
+export default {
+    title: "hello",
+};
+
+function add(a: number, b: number) {
+    return a + b;
+}
+
+`;
+
+exports[`import-export-in-between-side-effect.ts - typescript-verify: import-export-in-between-side-effect.ts 1`] = `
 import "side-effect";
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/tests/ImportsSeparated/__snapshots__/ppsi.spec.js.snap
+++ b/tests/ImportsSeparated/__snapshots__/ppsi.spec.js.snap
@@ -1,6 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`import-export-in-between.ts - typescript-verify: import-export-in-between.ts 1`] = `
+import "side-effect";
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";
 import thirdParty from "third-party";
@@ -22,6 +23,8 @@ function add(a:number,b:number) {
   return a + b;
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import "side-effect";
+
 import a from "a";
 import c from "c";
 import thirdParty from "third-party";
@@ -100,9 +103,9 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
-import React from "react";
-
 import "./commands";
+
+import React from "react";
 
 // Comment
 // Comment

--- a/tests/ImportsSeparated/import-export-in-between-side-effect.ts
+++ b/tests/ImportsSeparated/import-export-in-between-side-effect.ts
@@ -1,3 +1,4 @@
+import "side-effect";
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";
 import thirdParty from "third-party";

--- a/tests/ImportsSeparated/import-export-in-between.ts
+++ b/tests/ImportsSeparated/import-export-in-between.ts
@@ -1,3 +1,4 @@
+import "side-effect";
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";
 import thirdParty from "third-party";

--- a/tests/ImportsSeparatedRest/__snapshots__/ppsi.spec.js.snap
+++ b/tests/ImportsSeparatedRest/__snapshots__/ppsi.spec.js.snap
@@ -100,9 +100,9 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
-import React from "react";
-
 import "./commands";
+
+import React from "react";
 
 // Comment
 // Comment

--- a/tests/Typescript/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Typescript/__snapshots__/ppsi.spec.js.snap
@@ -1,5 +1,119 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`import-with-side-effect-imports.ts - typescript-verify: import-with-side-effect-imports.ts 1`] = `
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+
+import "side-effect-z";
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+import thirdDisco1 from "third-disco1";
+import otherthing0 from "@core/otherthing0";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import thirdParty1 from "third-party1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+
+import "side-effect-y";
+
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import something2 from "@core/something2";
+import thirdParty3 from "third-party3";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import otherthing2 from "@core/otherthing2";
+import thirdDisco3 from "third-disco3";
+
+import "side-effect-x";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+import something1 from "@core/something1";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import otherthing1 from "@core/otherthing1";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "app-root",
+  templateUrl: "./app.component.html",
+  styleUrls: ["./app.component.css"]
+})
+export class AppComponent extends BaseComponent {
+  title = "ng-prettier";
+
+  override get text(): string {
+    return isEmpty(this.title) ? "" : this.title;
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import thirdDisco0 from "third-disco0";
+import thirdParty0 from "third-party0";
+
+import otherthing3 from "@core/otherthing3";
+import something3 from "@core/something3";
+
+import "side-effect-z";
+
+import thirdDisco1 from "third-disco1";
+import thirdParty1 from "third-party1";
+
+import otherthing0 from "@core/otherthing0";
+import something0 from "@core/something0";
+
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+
+import "side-effect-y";
+
+import thirdDisco3 from "third-disco3";
+import thirdParty3 from "third-party3";
+
+import otherthing2 from "@core/otherthing2";
+import something2 from "@core/something2";
+
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+
+import "side-effect-x";
+
+import { Component } from "@angular/core";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import otherthing1 from "@core/otherthing1";
+import something1 from "@core/something1";
+
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+
+@Component({
+    selector: "app-root",
+    templateUrl: "./app.component.html",
+    styleUrls: ["./app.component.css"],
+})
+export class AppComponent extends BaseComponent {
+    title = "ng-prettier";
+
+    override get text(): string {
+        return isEmpty(this.title) ? "" : this.title;
+    }
+}
+
+`;
+
 exports[`imports-with-comments.ts - typescript-verify: imports-with-comments.ts 1`] = `
 import z from 'z';
 import { isEmpty } from "lodash-es";

--- a/tests/Typescript/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Typescript/__snapshots__/ppsi.spec.js.snap
@@ -17,7 +17,9 @@ import thirdParty1 from "third-party1";
 import oneLevelRelativePath1 from "../oneLevelRelativePath1";
 import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
 
-import "side-effect-y";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
 
 import oneLevelRelativePath2 from "../oneLevelRelativePath2";
 import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
@@ -72,7 +74,9 @@ import oneLevelRelativePath1 from "../oneLevelRelativePath1";
 import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
 import sameLevelRelativePath3 from "./sameLevelRelativePath3";
 
-import "side-effect-y";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
 
 import thirdDisco3 from "third-disco3";
 import thirdParty3 from "third-party3";

--- a/tests/Typescript/import-with-side-effect-imports.ts
+++ b/tests/Typescript/import-with-side-effect-imports.ts
@@ -14,7 +14,9 @@ import thirdParty1 from "third-party1";
 import oneLevelRelativePath1 from "../oneLevelRelativePath1";
 import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
 
-import "side-effect-y";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
 
 import oneLevelRelativePath2 from "../oneLevelRelativePath2";
 import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";

--- a/tests/Typescript/import-with-side-effect-imports.ts
+++ b/tests/Typescript/import-with-side-effect-imports.ts
@@ -1,0 +1,51 @@
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+
+import "side-effect-z";
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+import thirdDisco1 from "third-disco1";
+import otherthing0 from "@core/otherthing0";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import thirdParty1 from "third-party1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+
+import "side-effect-y";
+
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import something2 from "@core/something2";
+import thirdParty3 from "third-party3";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import otherthing2 from "@core/otherthing2";
+import thirdDisco3 from "third-disco3";
+
+import "side-effect-x";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+import something1 from "@core/something1";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import otherthing1 from "@core/otherthing1";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "app-root",
+  templateUrl: "./app.component.html",
+  styleUrls: ["./app.component.css"]
+})
+export class AppComponent extends BaseComponent {
+  title = "ng-prettier";
+
+  override get text(): string {
+    return isEmpty(this.title) ? "" : this.title;
+  }
+}


### PR DESCRIPTION
This PR resolves #110

* The relative order of side effect and non side effect imports is now preseverd by default. See the readme and issue for more info.
* I renamed the `getSortedNodes` method to `getSortedNodesByImportOrder`; and added a new implementation for `getSortedNodes` that first splits the imports at each side effect node, then sorts each chunk via the original `getSortedNodesByImportOrder`. I also moved the logic for adjusting comments and inserting new lines to the new `getSortedNodes` method. 
* With the exception of one test case (`imports-with-comments-and-third-party` has a side effect import `import "./commands"`), all existing tests still pass without any modifications.  This leads me to believe you haven't considered these kind of import statements yet and how they should be treated. So this PR could be thought of as defining the behavior for that scenario.
* I also added a few additional tests for the new behavior with side effect imports.

The way this PR is implemented (only performing less sorting in case of side effect imports) means that all source files that were considered formatted correctly before this PR are still considered to be formatted correctly. So this change should not require a new major version (assuming you are following semver). Also,  [prettier](https://github.com/prettier/prettier/issues/2201) recommends users to use an exact version, so the same should also apply to plugins.

That only leaves the question of whether (a) we should introduce an option that can turn side effect import sorting on and off, and (b) if so, what  should be the default. My opinion is no, following the philosophy of prettier, which is to be an opinionated code formatter without many options. Not sorting side effects should also be the default, as having side effects is the only purpose of those imports and changing their order is more likely to break the code.