### PR TITLE
Update file paths in DEBUG documentation

### DIFF
--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -4,13 +4,13 @@
 
 ### How to run example in the repository ?
 ```shell
-yarn run example examples/example.ts --config .prettierrc
+yarn run example examples/example.ts --config examples/.prettierrc
 ```
 
 ### How to debug the plugin using node `debugger` ?
 You can set a `debugger` anywhere in the code and then use following command:
 ```shell
-yarn run compile && node --inspect-brk ./node_modules/.bin/prettier --config .prettierrc --plugin lib/src/index.js examples/example.ts
+yarn run compile && node --inspect-brk ./node_modules/.bin/prettier --config examples/.prettierrc --plugin lib/src/index.js examples/example.ts
 ```
 
 ### How to debug the unit test using `debugger` ?

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { logger } from '@core/logger';
 import { reduce, debounce } from 'lodash';
-import { Message } from '../Mesage';
+import { Message } from '../Message';
 import { createServer } from '@server/node';
 import { Alert } from '@ui/Alert';
 import { repeat, filter, add } from './utils';


### PR DESCRIPTION
`.prettierrc` now lives under `examples/.prettierrc`. Updated the commands to reflect new file paths.

Also fixed a small typo in the `example.ts` file