### PR TITLE
fix: make type fields optional and add JSDoc

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,9 @@ import { RequiredOptions } from 'prettier';
 
 import { PluginConfig } from '../types';
 
-export interface PrettierOptions extends PluginConfig, RequiredOptions {}
+export interface PrettierOptions
+    extends Required<PluginConfig>,
+        RequiredOptions {}
 
 export type ImportGroups = Record<string, ImportDeclaration[]>;
 export type ImportOrLine = ImportDeclaration | ExpressionStatement;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,7 @@
+import { ParserPlugin as BaseParserPlugin } from '@babel/parser';
 import { Config } from 'prettier';
+
+type ParserPlugin = Extract<BaseParserPlugin, string> | `[${string},${string}]`;
 
 export interface PluginConfig {
     /**
@@ -86,7 +89,7 @@ used to order imports within each match group.
      *
      * @default ["typescript", "jsx"]
      */
-    importOrderParserPlugins?: string[];
+    importOrderParserPlugins?: ParserPlugin[];
 }
 
 export type PrettierConfig = PluginConfig & Config;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,9 @@
-import { ParserPlugin as BaseParserPlugin } from '@babel/parser';
+import { ParserPlugin } from '@babel/parser';
 import { Config } from 'prettier';
 
-type ParserPlugin = Extract<BaseParserPlugin, string> | `[${string},${string}]`;
+export type ImportOrderParserPlugin =
+    | Extract<ParserPlugin, string>
+    | `[${string},${string}]`;
 
 export interface PluginConfig {
     /**
@@ -89,7 +91,7 @@ used to order imports within each match group.
      *
      * @default ["typescript", "jsx"]
      */
-    importOrderParserPlugins?: ParserPlugin[];
+    importOrderParserPlugins?: ImportOrderParserPlugin[];
 }
 
 export type PrettierConfig = PluginConfig & Config;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,13 +1,92 @@
 import { Config } from 'prettier';
 
 export interface PluginConfig {
+    /**
+     * A collection of Regular expressions in string format.
+     *
+     * ```
+     * "importOrder": ["^@core/(.*)$", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"],
+     * ```
+     *
+     * _Default behavior:_ The plugin moves the third party imports to the top which are not part of the `importOrder` list.
+     * To move the third party imports at desired place, you can use `<THIRD_PARTY_MODULES>` to assign third party imports to the appropriate position:
+     *
+     * ```
+     * "importOrder": ["^@core/(.*)$", "<THIRD_PARTY_MODULES>", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"],
+     * ```
+     */
     importOrder: string[];
-    importOrderCaseInsensitive: boolean;
-    // should be of type ParserPlugin from '@babel/parser' but prettier does not support nested arrays in options
-    importOrderParserPlugins: string[];
-    importOrderSeparation: boolean;
-    importOrderGroupNamespaceSpecifiers: boolean;
-    importOrderSortSpecifiers: boolean;
+
+    /**
+     * A boolean value to enable or disable the new line separation
+     * between sorted import declarations group. The separation takes place according to the `importOrder`.
+     *
+     * @default false
+     */
+    importOrderSeparation?: boolean;
+
+    /**
+     * A boolean value to enable or disable sorting of the specifiers in an import declarations.
+     *
+     * @default false
+     */
+    importOrderSortSpecifiers?: boolean;
+
+    /**
+     * A boolean value to enable or disable sorting the namespace specifiers to the top of the import group.
+     *
+     * @default false
+     */
+    importOrderGroupNamespaceSpecifiers?: boolean;
+
+    /**
+     * A boolean value to enable case-insensitivity in the sorting algorithm
+used to order imports within each match group.
+     * 
+     * For example, when false (or not specified):
+     * 
+     * ```js
+     * import ExampleView from './ExampleView';
+     * import ExamplesList from './ExamplesList';
+     * ```
+     * 
+     * compared with `"importOrderCaseInsensitive": true`:
+     * 
+     * ```js
+     * import ExamplesList from './ExamplesList';
+     * import ExampleView from './ExampleView';
+     * ```
+     * 
+     * @default false
+     */
+    importOrderCaseInsensitive?: boolean;
+
+    /**
+     * Previously known as `experimentalBabelParserPluginsList`.
+     *
+     * A collection of plugins for babel parser. The plugin passes this list to babel parser, so it can understand the syntaxes
+     * used in the file being formatted. The plugin uses prettier itself to figure out the parser it needs to use but if that fails,
+     * you can use this field to enforce the usage of the plugins' babel parser needs.
+     *
+     * **To pass the plugins to babel parser**:
+     *
+     * ```
+     * "importOrderParserPlugins" : ["classProperties", "decorators-legacy"]
+     * ```
+     *
+     * **To pass the options to the babel parser plugins**: Since prettier options are limited to string, you can pass plugins
+     * with options as a JSON string of the plugin array:
+     * `"[\"plugin-name\", { \"pluginOption\": true }]"`.
+     *
+     * ```
+     * "importOrderParserPlugins" : ["classProperties", "[\"decorators\", { \"decoratorsBeforeExport\": true }]"]
+     * ```
+     *
+     * **To disable default plugins for babel parser, pass an empty array**:
+     *
+     * @default ["typescript", "jsx"]
+     */
+    importOrderParserPlugins?: string[];
 }
 
 export type PrettierConfig = PluginConfig & Config;


### PR DESCRIPTION
In the last PR, I made some mistakes there about forgetting to make some options optional. Sorry for that 😅.

In addition to that, I add JSDoc because I think it is nice to have.

I also type the `importOrderParserPlugins` with the appropriate type to help with checking and autocomplete.