### PR TITLE
fixed empty/no script tag in vue component error

### DIFF
--- a/examples/example.vue
+++ b/examples/example.vue
@@ -1,0 +1,33 @@
+<template>
+	<div>
+		<span>hello world
+		</span></div>
+</template>
+
+<script>
+// I am top level comment in this file.
+// I am second line of top level comment in this file.
+import threeLevelRelativePath from '../../../threeLevelRelativePath';
+import sameLevelRelativePath from './sameLevelRelativePath';
+import thirdParty from 'third-party';
+import React from 'react';
+export { random } from './random';
+import oneLevelRelativePath from '../oneLevelRelativePath';
+import otherthing from '@core/otherthing';
+import twoLevelRelativePath from '../../twoLevelRelativePath';
+import component from '@ui/hello';
+export default {
+    title: 'hello',
+};
+import fourLevelRelativePath from '../../../../fourLevelRelativePath';
+import something from '@server/something';
+
+function add(a, b) {
+    return a + b;
+}
+
+</script>
+
+<style>
+div { color: red; }
+</style>

--- a/src/preprocessors/vue-preprocessor.ts
+++ b/src/preprocessors/vue-preprocessor.ts
@@ -2,10 +2,13 @@ import { PrettierOptions } from '../types';
 import { preprocessor } from './preprocessor';
 
 export function vuePreprocessor(code: string, options: PrettierOptions) {
-    const { parse } = require('@vue/compiler-sfc')
+    const { parse } = require('@vue/compiler-sfc');
     const { descriptor } = parse(code);
-    const content =
-        (descriptor.script ?? descriptor.scriptSetup)?.content ?? code;
+
+    const content = (descriptor.script ?? descriptor.scriptSetup)?.content;
+    if (!content) {
+        return code;
+    }
 
     return code.replace(content, `\n${preprocessor(content, options)}\n`);
 }

--- a/tests/Vue/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Vue/__snapshots__/ppsi.spec.js.snap
@@ -112,6 +112,31 @@ export default defineComponent({});
 
 `;
 
+exports[`sfcNoScript.vue - vue-verify: sfcNoScript.vue 1`] = `
+<template>
+	<div>
+		<span>hello world
+		</span></div>
+</template>
+
+<style>
+div { color: red; }
+</style>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<template>
+    <div>
+        <span>hello world </span>
+    </div>
+</template>
+
+<style>
+div {
+    color: red;
+}
+</style>
+
+`;
+
 exports[`ts.vue - vue-verify: ts.vue 1`] = `
 <script lang="ts">
 // I am top level comment in this file.

--- a/tests/Vue/sfcNoScript.vue
+++ b/tests/Vue/sfcNoScript.vue
@@ -1,0 +1,9 @@
+<template>
+	<div>
+		<span>hello world
+		</span></div>
+</template>
+
+<style>
+div { color: red; }
+</style>


### PR DESCRIPTION
This should fix https://github.com/trivago/prettier-plugin-sort-imports/issues/191 if I've understood what `vue-preprocessor.ts` does

If there is no script value, just return the code as is