### PR TITLE
Escape dollars in Vue preprocessor replacement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v4.1.2
+#### New features
+- Fix dollars being interpolated in vue SFC [#217](https://github.com/trivago/prettier-plugin-sort-imports/pull/217) by [mefyl](https://github.com/mefyl)
 
 ---
 ### v4.1.1

--- a/src/preprocessors/vue-preprocessor.ts
+++ b/src/preprocessors/vue-preprocessor.ts
@@ -9,6 +9,6 @@ export function vuePreprocessor(code: string, options: PrettierOptions) {
     if (!content) {
         return code;
     }
-
-    return code.replace(content, `\n${preprocessor(content, options)}\n`);
+    const replacement = preprocessor(content, options).replace(/\$/g, '$$$$');
+    return code.replace(content, `\n${replacement}\n`);
 }

--- a/tests/Vue/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Vue/__snapshots__/ppsi.spec.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`dollar-escaping.vue - vue-verify: dollar-escaping.vue 1`] = `
+<template>
+  <div></div>
+</template>
+
+<script lang="ts">
+const x = new RegExp(\`\${x}$\`);
+</script>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<template>
+    <div></div>
+</template>
+
+<script lang="ts">
+const x = new RegExp(\`\${x}$\`);
+</script>
+
+`;
+
 exports[`setup.vue - vue-verify: setup.vue 1`] = `
 <script setup>
 // I am top level comment in this file.

--- a/tests/Vue/dollar-escaping.vue
+++ b/tests/Vue/dollar-escaping.vue
@@ -1,0 +1,7 @@
+<template>
+  <div></div>
+</template>
+
+<script lang="ts">
+const x = new RegExp(`${x}$`);
+</script>


### PR DESCRIPTION
Fix dollars followed by eg. backtick being interpreted as backreferences in Vue preprocessor. See included minimal unit test.