### PR TITLE
chore: Update `README` for `prettier` v3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ module.exports = {
 }
 ```
 
-**Note: There may be an issue with some package managers, such as `pnpm`. You can solve it by providing additional configuration option in prettier config file.
+**Note: There may be an issue with some package managers, such as `pnpm` or when using `prettier` v3.x. You can solve it by providing additional configuration option in prettier config file.
 
 ```js
 module.exports = {


### PR DESCRIPTION
While testing with prettier v3 I found that it is now necessary to add the plugin to the config with `npm` (when I never had to before) as per: 
```
module.exports = {
    ...
    "plugins": ["@trivago/prettier-plugin-sort-imports"]
}
```
https://github.com/trivago/prettier-plugin-sort-imports#usage