### PR TITLE
Fix prepare script, consumers should not need to have yarn to be able to install package as a git dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/trivago/prettier-plugin-sort-imports#readme",
   "scripts": {
-    "prepare": "yarn run compile",
+    "prepare": "tsc",
     "compile": "tsc",
     "preexample": "yarn run compile",
     "example": "prettier --config ./examples/.prettierrc --plugin lib/src/index.js",


### PR DESCRIPTION
Currently when installing the package it will crash if yarn isn't installed. Because the prepare script runs on consumers machines after install.

Suggested solution: Run tsc directly instead.

---
*Thanks for this nice package by the way! 🎉*