### PR TITLE
chore: describe the sort-imports-ignore comment in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,17 @@ with options as a JSON string of the plugin array:
 importOrderParserPlugins: []
 ```
 
+### Ignoring import ordering
+
+In some cases it's desired to ignore import ordering, specifically if you require to instantiate a common service or polyfill in your application logic before all the other imports. The plugin supports the `// sort-imports-ignore` comment, which will exclude the file from ordering the imports.
+
+```javascript
+// sort-imports-ignore
+import './polyfills';
+
+import foo from 'foo'
+```
+
 ### How does import sort work ?
 
 The plugin extracts the imports which are defined in `importOrder`. These imports are considered as _local imports_.


### PR DESCRIPTION
This PR includes documentation on the supported `// sort-imports-ignore` comment.

This [original issue](https://github.com/trivago/prettier-plugin-sort-imports/issues/230) describes the support for the comment, however documentation was not added in the README.