### PR TITLE
feature: order respects side effect imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,37 @@ with options as a JSON string of the plugin array:
 importOrderParserPlugins: []
 ```
 
+### `importOrderSideEffects`
+**type**: `boolean`
+**default value**: `true`
+
+By default, the plugin sorts [side effect imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#import_a_module_for_its_side_effects_only) like any other imports in the file. If you need to keep side effect imports in the same place but sort all other imports around them, set this option to false.
+
+Example:
+
+Initial file:
+
+```js
+import z from 'z'
+import a from 'a'
+
+import 'side-effect-lib'
+
+import c from 'c'
+import b from 'b'
+```
+When sorted:
+
+```js
+import a from 'a'
+import z from 'z'
+
+import 'side-effect-lib'
+
+import b from 'b'
+import c from 'c'
+```
+
 ### How does import sort work ?
 
 The plugin extracts the imports which are defined in `importOrder`. These imports are considered as _local imports_.

--- a/examples/example.jsx
+++ b/examples/example.jsx
@@ -8,7 +8,6 @@ import otherthing from '@core/otherthing';
 import twoLevelRelativePath from '../../twoLevelRelativePath';
 import component from '@ui/hello';
 
-
 const HelloWorld = ({ name }) => {
     return <div>Hello, {name}</div>;
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,9 @@ export const newLineCharacters = '\n\n';
 
 export const sortImportsIgnoredComment = 'sort-imports-ignore';
 
+export const chunkSideEffectNode = 'side-effect-node';
+export const chunkSideOtherNode = 'other-node';
+
 /*
  * Used to mark the position between RegExps,
  * where the not matched imports should be placed

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,10 @@ import { parsers as babelParsers } from 'prettier/plugins/babel';
 import { parsers as flowParsers } from 'prettier/plugins/flow';
 import { parsers as htmlParsers } from 'prettier/plugins/html';
 import { parsers as typescriptParsers } from 'prettier/plugins/typescript';
+
 import { defaultPreprocessor } from './preprocessors/default-processor';
-import { vuePreprocessor } from './preprocessors/vue-preprocessor';
 import { sveltePreprocessor } from './preprocessors/svelte-preprocessor';
+import { vuePreprocessor } from './preprocessors/vue-preprocessor';
 
 const { parsers: svelteParsers } = require('prettier-plugin-svelte');
 
@@ -49,6 +50,12 @@ const options = {
         category: 'Global',
         default: false,
         description: 'Should specifiers be sorted?',
+    },
+    importOrderSideEffects: {
+        type: 'boolean',
+        category: 'Global',
+        default: true,
+        description: 'Should side effects be sorted?',
     },
 };
 

--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -16,6 +16,7 @@ export function preprocessor(code: string, options: PrettierOptions) {
         importOrderSeparation,
         importOrderGroupNamespaceSpecifiers,
         importOrderSortSpecifiers,
+        importOrderSideEffects,
     } = options;
 
     const parserOptions: ParserOptions = {
@@ -42,6 +43,7 @@ export function preprocessor(code: string, options: PrettierOptions) {
         importOrderSeparation,
         importOrderGroupNamespaceSpecifiers,
         importOrderSortSpecifiers,
+        importOrderSideEffects,
     });
 
     return getCodeFromAst(allImports, directives, code, interpreter);

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,5 +19,11 @@ export type GetSortedNodes = (
         | 'importOrderSeparation'
         | 'importOrderGroupNamespaceSpecifiers'
         | 'importOrderSortSpecifiers'
+        | 'importOrderSideEffects'
     >,
 ) => ImportOrLine[];
+
+export interface ImportChunk {
+    nodes: ImportDeclaration[];
+    type: string;
+}

--- a/src/utils/__tests__/adjust-comments-on-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/adjust-comments-on-sorted-nodes.spec.ts
@@ -1,0 +1,107 @@
+import { ImportDeclaration } from '@babel/types';
+
+import { adjustCommentsOnSortedNodes } from '../adjust-comments-on-sorted-nodes';
+import { getImportNodes } from '../get-import-nodes';
+
+function leadingComments(node: ImportDeclaration): string[] {
+    return node.leadingComments?.map((c) => c.value) ?? [];
+}
+
+function trailingComments(node: ImportDeclaration): string[] {
+    return node.trailingComments?.map((c) => c.value) ?? [];
+}
+
+test('it preserves the single leading comment for each import declaration', () => {
+    const importNodes = getImportNodes(`
+    import {x} from "c";
+    // comment b
+    import {y} from "b";
+    // comment a
+    import {z} from "a";
+    `);
+    expect(importNodes).toHaveLength(3);
+    const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
+    adjustCommentsOnSortedNodes(importNodes, finalNodes);
+    expect(finalNodes).toHaveLength(3);
+    expect(leadingComments(finalNodes[0])).toEqual([' comment a']);
+    expect(trailingComments(finalNodes[0])).toEqual([]);
+    expect(leadingComments(finalNodes[1])).toEqual([' comment b']);
+    expect(trailingComments(finalNodes[1])).toEqual([]);
+    expect(leadingComments(finalNodes[2])).toEqual([]);
+    expect(trailingComments(finalNodes[2])).toEqual([]);
+});
+
+test('it preserves multiple leading comments for each import declaration', () => {
+    const importNodes = getImportNodes(`
+    import {x} from "c";
+    // comment b1
+    // comment b2
+    // comment b3
+    import {y} from "b";
+    // comment a1
+    // comment a2
+    // comment a3
+    import {z} from "a";
+    `);
+    expect(importNodes).toHaveLength(3);
+    const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
+    adjustCommentsOnSortedNodes(importNodes, finalNodes);
+    expect(finalNodes).toHaveLength(3);
+    expect(leadingComments(finalNodes[0])).toEqual([
+        ' comment a1',
+        ' comment a2',
+        ' comment a3',
+    ]);
+    expect(trailingComments(finalNodes[0])).toEqual([]);
+    expect(leadingComments(finalNodes[1])).toEqual([
+        ' comment b1',
+        ' comment b2',
+        ' comment b3',
+    ]);
+    expect(trailingComments(finalNodes[1])).toEqual([]);
+    expect(leadingComments(finalNodes[2])).toEqual([]);
+    expect(trailingComments(finalNodes[2])).toEqual([]);
+});
+
+test('it does not move comments at before all import declarations', () => {
+    const importNodes = getImportNodes(`
+    // comment c1
+    // comment c2
+    import {x} from "c";
+    import {y} from "b";
+    import {z} from "a";
+    `);
+    expect(importNodes).toHaveLength(3);
+    const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
+    adjustCommentsOnSortedNodes(importNodes, finalNodes);
+    expect(finalNodes).toHaveLength(3);
+    expect(leadingComments(finalNodes[0])).toEqual([
+        ' comment c1',
+        ' comment c2',
+    ]);
+    expect(trailingComments(finalNodes[0])).toEqual([]);
+    expect(leadingComments(finalNodes[1])).toEqual([]);
+    expect(trailingComments(finalNodes[1])).toEqual([]);
+    expect(leadingComments(finalNodes[2])).toEqual([]);
+    expect(trailingComments(finalNodes[2])).toEqual([]);
+});
+
+test('it does not affect comments after all import declarations', () => {
+    const importNodes = getImportNodes(`
+    import {x} from "c";
+    import {y} from "b";
+    import {z} from "a";
+    // comment final 1
+    // comment final 2
+    `);
+    expect(importNodes).toHaveLength(3);
+    const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
+    adjustCommentsOnSortedNodes(importNodes, finalNodes);
+    expect(finalNodes).toHaveLength(3);
+    expect(leadingComments(finalNodes[0])).toEqual([]);
+    expect(trailingComments(finalNodes[0])).toEqual([]);
+    expect(leadingComments(finalNodes[1])).toEqual([]);
+    expect(trailingComments(finalNodes[1])).toEqual([]);
+    expect(leadingComments(finalNodes[2])).toEqual([]);
+    expect(trailingComments(finalNodes[2])).toEqual([]);
+});

--- a/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
+++ b/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
@@ -14,6 +14,7 @@ const getSortedImportNodes = (code: string, options?: ParserOptions) => {
         importOrderSeparation: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
+        importOrderSideEffects: true,
     });
 };
 

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -25,6 +25,7 @@ import a from 'a';
         importOrderSeparation: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
+        importOrderSideEffects: true,
     });
     const formatted = getCodeFromAst(sortedNodes, [], code, null);
     expect(await format(formatted, { parser: 'babel' })).toEqual(

--- a/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
@@ -20,24 +20,6 @@ import XY from 'XY';
 import Xa from 'Xa';
 `;
 
-const typeCode = `// first comment
-// second comment
-import type sm from 'sm';
-import type xl from './xl';
-import l from './l';
-import z from 'z';
-import c, { cD } from 'c';
-import g from 'g';
-import { tC, tA, tB } from 't';
-import k, { kE, kB } from 'k';
-import * as a from 'a';
-import * as x from 'x';
-import BY from 'BY';
-import Ba from 'Ba';
-import XY from 'XY';
-import Xa from 'Xa';
-`;
-
 test('it returns all sorted nodes', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodes(result, {
@@ -353,58 +335,5 @@ test('it returns all sorted nodes with namespace specifiers at the top', () => {
         'k',
         't',
         'z',
-    ]);
-});
-
-test('it returns all sorted nodes with types', () => {
-    const result = getImportNodes(typeCode, {
-        plugins: ['typescript'],
-    });
-    const sorted = getSortedNodes(result, {
-        importOrder: ['<THIRD_PARTY_TS_TYPES>', '^[./]', '<TS_TYPES>^[./]'],
-        importOrderCaseInsensitive: false,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderSortSpecifiers: false,
-        importOrderSideEffects: true,
-    }) as ImportDeclaration[];
-
-    expect(getSortedNodesNames(sorted)).toEqual([
-        'BY',
-        'Ba',
-        'XY',
-        'Xa',
-        'a',
-        'c',
-        'g',
-        'k',
-        't',
-        'x',
-        'z',
-        'sm',
-        './l',
-        './xl',
-    ]);
-    expect(
-        sorted
-            .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) =>
-                getSortedNodesModulesNames(importDeclaration.specifiers),
-            ),
-    ).toEqual([
-        ['BY'],
-        ['Ba'],
-        ['XY'],
-        ['Xa'],
-        ['a'],
-        ['c', 'cD'],
-        ['g'],
-        ['k', 'kE', 'kB'],
-        ['tC', 'tA', 'tB'],
-        ['x'],
-        ['z'],
-        ['sm'],
-        ['l'],
-        ['xl'],
     ]);
 });

--- a/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
+++ b/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
@@ -25,6 +25,7 @@ test('it should remove nodes from the original code', async () => {
         importOrderSeparation: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
+        importOrderSideEffects: true,
     });
     const allCommentsFromImports = getAllCommentsFromNodes(sortedNodes);
 
@@ -36,6 +37,8 @@ test('it should remove nodes from the original code', async () => {
         code,
         commentAndImportsToRemoveFromCode,
     );
-    const result = await format(codeWithoutImportDeclarations, { parser: 'babel' });
+    const result = await format(codeWithoutImportDeclarations, {
+        parser: 'babel',
+    });
     expect(result).toEqual('');
 });

--- a/src/utils/adjust-comments-on-sorted-nodes.ts
+++ b/src/utils/adjust-comments-on-sorted-nodes.ts
@@ -1,0 +1,42 @@
+import { ImportDeclaration, addComments, removeComments } from '@babel/types';
+import { clone, isEqual } from 'lodash';
+
+import { ImportOrLine } from '../types';
+
+/**
+ * Takes the original nodes before sorting and the final nodes after sorting.
+ * Adjusts the comments on the final nodes so that they match the comments as
+ * they were in the original nodes.
+ * @param nodes A list of nodes in the order as they were originally.
+ * @param finalNodes The same set of nodes, but in the final sorting order.
+ */
+export const adjustCommentsOnSortedNodes = (
+    nodes: ImportDeclaration[],
+    finalNodes: ImportOrLine[],
+) => {
+    // maintain a copy of the nodes to extract comments from
+    const finalNodesClone = finalNodes.map(clone);
+
+    const firstNodesComments = nodes[0].leadingComments;
+
+    // Remove all comments from sorted nodes
+    finalNodes.forEach(removeComments);
+
+    // insert comments other than the first comments
+    finalNodes.forEach((node, index) => {
+        if (isEqual(nodes[0].loc, node.loc)) return;
+        // remove comments location to not confuse print AST
+        firstNodesComments?.forEach((comment) => {
+            delete comment.loc;
+        });
+        addComments(
+            node,
+            'leading',
+            finalNodesClone[index].leadingComments || [],
+        );
+    });
+
+    if (firstNodesComments) {
+        addComments(finalNodes[0], 'leading', firstNodesComments);
+    }
+};

--- a/src/utils/get-all-comments-from-nodes.ts
+++ b/src/utils/get-all-comments-from-nodes.ts
@@ -1,12 +1,15 @@
 import { CommentBlock, CommentLine, Statement } from '@babel/types';
 
 export const getAllCommentsFromNodes = (nodes: Statement[]) =>
-    nodes.reduce((acc, node) => {
-        if (
-            Array.isArray(node.leadingComments) &&
-            node.leadingComments.length > 0
-        ) {
-            acc = [...acc, ...node.leadingComments];
-        }
-        return acc;
-    }, [] as (CommentBlock | CommentLine)[]);
+    nodes.reduce(
+        (acc, node) => {
+            if (
+                Array.isArray(node.leadingComments) &&
+                node.leadingComments.length > 0
+            ) {
+                acc = [...acc, ...node.leadingComments];
+            }
+            return acc;
+        },
+        [] as (CommentBlock | CommentLine)[],
+    );

--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -1,0 +1,78 @@
+import { clone } from 'lodash';
+
+import { THIRD_PARTY_MODULES_SPECIAL_WORD, newLineNode } from '../constants';
+import { naturalSort } from '../natural-sort';
+import { GetSortedNodes, ImportGroups, ImportOrLine } from '../types';
+import { getImportNodesMatchedGroup } from './get-import-nodes-matched-group';
+import { getSortedImportSpecifiers } from './get-sorted-import-specifiers';
+import { getSortedNodesGroup } from './get-sorted-nodes-group';
+
+/**
+ * This function returns the given nodes, sorted in the order as indicated by
+ * the importOrder array from the given options.
+ * The plugin considers these import nodes as local import declarations.
+ * @param nodes A subset of all import nodes that should be sorted.
+ * @param options Options to influence the behavior of the sorting algorithm.
+ */
+export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
+    naturalSort.insensitive = options.importOrderCaseInsensitive;
+
+    let { importOrder } = options;
+    const {
+        importOrderSeparation,
+        importOrderSortSpecifiers,
+        importOrderGroupNamespaceSpecifiers,
+    } = options;
+
+    const originalNodes = nodes.map(clone);
+    const finalNodes: ImportOrLine[] = [];
+
+    if (!importOrder.includes(THIRD_PARTY_MODULES_SPECIAL_WORD)) {
+        importOrder = [THIRD_PARTY_MODULES_SPECIAL_WORD, ...importOrder];
+    }
+
+    const importOrderGroups = importOrder.reduce<ImportGroups>(
+        (groups, regexp) => ({
+            ...groups,
+            [regexp]: [],
+        }),
+        {},
+    );
+
+    const importOrderWithOutThirdPartyPlaceholder = importOrder.filter(
+        (group) => group !== THIRD_PARTY_MODULES_SPECIAL_WORD,
+    );
+
+    for (const node of originalNodes) {
+        const matchedGroup = getImportNodesMatchedGroup(
+            node,
+            importOrderWithOutThirdPartyPlaceholder,
+        );
+        importOrderGroups[matchedGroup].push(node);
+    }
+
+    for (const group of importOrder) {
+        const groupNodes = importOrderGroups[group];
+
+        if (groupNodes.length === 0) continue;
+
+        const sortedInsideGroup = getSortedNodesGroup(groupNodes, {
+            importOrderGroupNamespaceSpecifiers,
+        });
+
+        // Sort the import specifiers
+        if (importOrderSortSpecifiers) {
+            sortedInsideGroup.forEach((node) =>
+                getSortedImportSpecifiers(node),
+            );
+        }
+
+        finalNodes.push(...sortedInsideGroup);
+
+        if (importOrderSeparation) {
+            finalNodes.push(newLineNode);
+        }
+    }
+
+    return finalNodes;
+};

--- a/src/utils/get-sorted-nodes.ts
+++ b/src/utils/get-sorted-nodes.ts
@@ -1,110 +1,74 @@
-import { addComments, removeComments } from '@babel/types';
-import { clone, isEqual } from 'lodash';
-
-import { THIRD_PARTY_MODULES_SPECIAL_WORD, newLineNode } from '../constants';
-import { naturalSort } from '../natural-sort';
-import { GetSortedNodes, ImportGroups, ImportOrLine } from '../types';
-import { getImportNodesMatchedGroup } from './get-import-nodes-matched-group';
-import { getSortedImportSpecifiers } from './get-sorted-import-specifiers';
-import { getSortedNodesGroup } from './get-sorted-nodes-group';
+import {
+    chunkSideEffectNode,
+    chunkSideOtherNode,
+    newLineNode,
+} from '../constants';
+import { GetSortedNodes, ImportChunk, ImportOrLine } from '../types';
+import { adjustCommentsOnSortedNodes } from './adjust-comments-on-sorted-nodes';
+import { getSortedNodesByImportOrder } from './get-sorted-nodes-by-import-order';
 
 /**
- * This function returns all the nodes which are in the importOrder array.
- * The plugin considered these import nodes as local import declarations.
- * @param nodes all import nodes
- * @param options
+ * This function returns the given nodes, sorted in the order as indicated by
+ * the importOrder array. The plugin considers these import nodes as local
+ * import declarations
+ *
+ * In addition, this method preserves the relative order of side effect imports
+ * and non side effect imports. A side effect import is an ImportDeclaration
+ * without any import specifiers. It does this by splitting the import nodes at
+ * each side effect node, then sorting only the non side effect import nodes
+ * between the side effect nodes according to the given options.
+ * @param nodes All import nodes that should be sorted.
+ * @param options Options to influence the behavior of the sorting algorithm.
  */
 export const getSortedNodes: GetSortedNodes = (nodes, options) => {
-    naturalSort.insensitive = options.importOrderCaseInsensitive;
+    const { importOrderSeparation, importOrderSideEffects } =
+        options;
 
-    let { importOrder } = options;
-    const {
-        importOrderSeparation,
-        importOrderSortSpecifiers,
-        importOrderGroupNamespaceSpecifiers,
-    } = options;
+    // Split nodes at each boundary between a side-effect node and a
+    // non-side-effect node, keeping both types of nodes together.
+    const splitBySideEffectNodes = nodes.reduce<ImportChunk[]>(
+        (chunks, node) => {
+            const isChunkEffectNode =
+                node.specifiers.length === 0 &&
+                importOrderSideEffects === false;
+            const type = isChunkEffectNode
+                ? chunkSideEffectNode
+                : chunkSideOtherNode;
+            const last = chunks[chunks.length - 1];
+            if (last === undefined || last.type !== type) {
+                chunks.push({ type, nodes: [node] });
+            } else {
+                last.nodes.push(node);
+            }
+            return chunks;
+        },
+        [],
+    );
 
-    const originalNodes = nodes.map(clone);
     const finalNodes: ImportOrLine[] = [];
 
-    if (!importOrder.includes(THIRD_PARTY_MODULES_SPECIAL_WORD)) {
-        importOrder = [THIRD_PARTY_MODULES_SPECIAL_WORD, ...importOrder];
-    }
-
-    const importOrderGroups = importOrder.reduce<ImportGroups>(
-        (groups, regexp) => ({
-            ...groups,
-            [regexp]: [],
-        }),
-        {},
-    );
-
-    const importOrderWithOutThirdPartyPlaceholder = importOrder.filter(
-        (group) => group !== THIRD_PARTY_MODULES_SPECIAL_WORD,
-    );
-
-    for (const node of originalNodes) {
-        const matchedGroup = getImportNodesMatchedGroup(
-            node,
-            importOrderWithOutThirdPartyPlaceholder,
-        );
-        importOrderGroups[matchedGroup].push(node);
-    }
-
-    for (const group of importOrder) {
-        const groupNodes = importOrderGroups[group];
-
-        if (groupNodes.length === 0) continue;
-
-        const sortedInsideGroup = getSortedNodesGroup(groupNodes, {
-            importOrderGroupNamespaceSpecifiers,
-        });
-
-        // Sort the import specifiers
-        if (importOrderSortSpecifiers) {
-            sortedInsideGroup.forEach((node) =>
-                getSortedImportSpecifiers(node),
-            );
+    // Sort each chunk of side-effect and non-side-effect nodes, and insert new
+    // lines according the importOrderSeparation option.
+    for (const chunk of splitBySideEffectNodes) {
+        if (chunk.type === chunkSideEffectNode) {
+            // do not sort side effect nodes
+            finalNodes.push(...chunk.nodes);
+        } else {
+            // sort non-side effect nodes
+            const sorted = getSortedNodesByImportOrder(chunk.nodes, options);
+            finalNodes.push(...sorted);
         }
-
-        finalNodes.push(...sortedInsideGroup);
-
         if (importOrderSeparation) {
             finalNodes.push(newLineNode);
         }
     }
 
     if (finalNodes.length > 0 && !importOrderSeparation) {
-        // a newline after all imports
         finalNodes.push(newLineNode);
     }
 
-    // maintain a copy of the nodes to extract comments from
-    const finalNodesClone = finalNodes.map(clone);
-
-    const firstNodesComments = nodes[0].leadingComments;
-
-    // Remove all comments from sorted nodes
-    finalNodes.forEach(removeComments);
-
-    // insert comments other than the first comments
-    finalNodes.forEach((node, index) => {
-        if (isEqual(nodes[0].loc, node.loc)) return;
-
-        addComments(
-            node,
-            'leading',
-            finalNodesClone[index].leadingComments || [],
-        );
-    });
-
-    if (firstNodesComments) {
-        // remove comments location to not confuse printe
-        firstNodesComments.forEach((comment) => {
-            delete comment.loc;
-        });
-        addComments(finalNodes[0], 'leading', firstNodesComments);
-    }
+    // Adjust the comments on the sorted nodes to match the original comments
+    adjustCommentsOnSortedNodes(nodes, finalNodes);
 
     return finalNodes;
 };

--- a/src/utils/is-sort-imports-ignored.ts
+++ b/src/utils/is-sort-imports-ignored.ts
@@ -6,6 +6,7 @@ import { getAllCommentsFromNodes } from './get-all-comments-from-nodes';
 export const isSortImportsIgnored = (nodes: Statement[]) =>
     getAllCommentsFromNodes(nodes).some(
         (comment) =>
-            comment.loc && comment.loc.start.line === 1 &&
+            comment.loc &&
+            comment.loc.start.line === 1 &&
             comment.value.includes(sortImportsIgnoredComment),
     );

--- a/test-setup/run_spec.js
+++ b/test-setup/run_spec.js
@@ -35,7 +35,7 @@ function run_spec(dirname, parsers, options) {
             test(`${filename} - ${mergedOptions.parser}-verify`, async () => {
                 try {
                     expect(
-                        raw(source + '~'.repeat(80) + '\n' + await output),
+                        raw(source + '~'.repeat(80) + '\n' + (await output)),
                     ).toMatchSnapshot(filename);
                 } catch (e) {
                     console.error(e, path);

--- a/tests/ImportPreventSortingSideEffects/__snapshots__/ppsi.spec.js.snap
+++ b/tests/ImportPreventSortingSideEffects/__snapshots__/ppsi.spec.js.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`imports-with-side-effect-imports.js - typescript-verify: imports-with-side-effect-imports.js 1`] = `
+// I am top level comment in this file.
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+
+import "side-effect-z";
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+import thirdDisco1 from "third-disco1";
+import otherthing0 from "@core/otherthing0";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import thirdParty1 from "third-party1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
+
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import something2 from "@core/something2";
+import thirdParty3 from "third-party3";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import otherthing2 from "@core/otherthing2";
+import thirdDisco3 from "third-disco3";
+
+import "side-effect-x";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+import something1 from "@core/something1";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import otherthing1 from "@core/otherthing1";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import { Component } from "@angular/core";
+
+function add(a,b) {
+  return a + b;
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// I am top level comment in this file.
+import thirdDisco0 from "third-disco0";
+import thirdParty0 from "third-party0";
+
+import otherthing3 from "@core/otherthing3";
+import something3 from "@core/something3";
+
+import "side-effect-z";
+
+import thirdDisco1 from "third-disco1";
+import thirdParty1 from "third-party1";
+
+import otherthing0 from "@core/otherthing0";
+import something0 from "@core/something0";
+
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
+
+import thirdDisco3 from "third-disco3";
+import thirdParty3 from "third-party3";
+
+import otherthing2 from "@core/otherthing2";
+import something2 from "@core/something2";
+
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+
+import "side-effect-x";
+
+import { Component } from "@angular/core";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import otherthing1 from "@core/otherthing1";
+import something1 from "@core/something1";
+
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+
+function add(a, b) {
+    return a + b;
+}
+
+`;

--- a/tests/ImportPreventSortingSideEffects/imports-with-side-effect-imports.js
+++ b/tests/ImportPreventSortingSideEffects/imports-with-side-effect-imports.js
@@ -1,0 +1,45 @@
+// I am top level comment in this file.
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+
+import "side-effect-z";
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+import thirdDisco1 from "third-disco1";
+import otherthing0 from "@core/otherthing0";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import thirdParty1 from "third-party1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
+
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import something2 from "@core/something2";
+import thirdParty3 from "third-party3";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import otherthing2 from "@core/otherthing2";
+import thirdDisco3 from "third-disco3";
+
+import "side-effect-x";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+import something1 from "@core/something1";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import otherthing1 from "@core/otherthing1";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import { Component } from "@angular/core";
+
+function add(a,b) {
+  return a + b;
+}

--- a/tests/ImportPreventSortingSideEffects/ppsi.spec.js
+++ b/tests/ImportPreventSortingSideEffects/ppsi.spec.js
@@ -1,0 +1,6 @@
+run_spec(__dirname, ["typescript"], {
+    importOrder: ['^@core/(.*)$', '^@server/(.*)', '^@ui/(.*)$', '^[./]'],
+    importOrderSeparation: true,
+    importOrderSideEffects: false,
+    importOrderParserPlugins: ['typescript']
+});


### PR DESCRIPTION
# What have done

- cherry-picked changes from https://github.com/trivago/prettier-plugin-sort-imports/pull/111 Thanks to @blutorange for provided feature.
- by default sorting respects `importOrderPreventSortingSideEffectNodes` and turned off by default 
- formatted all files by prettier that weren't formatted yet