### PR TITLE
Fix svelte packages being required all the time

### DIFF
--- a/examples/.prettierrc
+++ b/examples/.prettierrc
@@ -3,9 +3,10 @@
     "tabWidth": 4,
     "trailingComma": "all",
     "singleQuote": true,
-    "jsxBracketSameLine": true,
+    "bracketSameLine": true,
     "semi": true,
     "importOrder": ["^@server/(.*)$", "^@core/(.*)$", "^@ui/(.*)$", "^[./]"],
     "importOrderSeparation": true,
-    "importOrderSortSpecifiers": true
+    "importOrderSortSpecifiers": true,
+    "plugins": ["../lib/src/index.js"]
 }

--- a/examples/example.svelte
+++ b/examples/example.svelte
@@ -1,0 +1,48 @@
+<script>
+	import { onMount } from 'svelte';
+    // I am top level comment in this file.
+    // I am second line of top level comment in this file.
+    import React from 'react';
+    import thirdParty from 'third-party';
+
+    import something from '@server/something';
+
+
+    import component from '@ui/hello';
+
+    import fourLevelRelativePath from '../../../../fourLevelRelativePath';
+    import threeLevelRelativePath from '../../../threeLevelRelativePath';
+    import twoLevelRelativePath from '../../twoLevelRelativePath';
+    import oneLevelRelativePath from '../oneLevelRelativePath';
+    import sameLevelRelativePath from './sameLevelRelativePath';
+ 
+    import otherthing from '@core/otherthing';
+	let count = 0;
+
+	function increment() {
+		count += 1;
+	}
+</script>
+
+<main>
+	<h1>Hello Svelte!</h1>
+	<p>The count is {count}</p>
+	<button on:click={increment}>Increment</button>
+</main>
+
+<style>
+	main {
+		text-align: center;
+		padding: 1em;
+		max-width: 240px;
+		margin: 0 auto;
+	}
+
+	h1 {
+		color: #ff3e00;
+	}
+
+	button {
+		font-size: 1.2em;
+	}
+</style>

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,12 @@ import { parsers as typescriptParsers } from 'prettier/plugins/typescript';
 import { defaultPreprocessor } from './preprocessors/default-processor';
 import { sveltePreprocessor } from './preprocessors/svelte-preprocessor';
 import { vuePreprocessor } from './preprocessors/vue-preprocessor';
+import type { Options } from 'prettier';
+import { createSvelteParsers } from './utils/create-svelte-parsers';
 
-const { parsers: svelteParsers } = require('prettier-plugin-svelte');
+const svelteParsers = createSvelteParsers();
 
-const options = {
+const options: Options = {
     importOrder: {
         type: 'path',
         category: 'Global',
@@ -62,7 +64,7 @@ const options = {
         category: 'Global',
         default: 'with',
         description: 'Provide a keyword for import attributes',
-    }
+    },
 };
 
 module.exports = {
@@ -84,7 +86,7 @@ module.exports = {
             preprocess: vuePreprocessor,
         },
         svelte: {
-            ...svelteParsers.svelte,
+            ...svelteParsers.parsers.svelte,
             preprocess: sveltePreprocessor,
         },
     },

--- a/src/utils/create-svelte-parsers.ts
+++ b/src/utils/create-svelte-parsers.ts
@@ -1,0 +1,8 @@
+export function createSvelteParsers() {
+    try {
+        var { parsers } = require('prettier-plugin-svelte');
+    } catch {
+        return {};
+    }
+    return { parsers };
+}


### PR DESCRIPTION
This PR tries to solve the issue in v5 that Svelte related packages were required for all project types.