### PR TITLE
Fix type import ordering

### DIFF
--- a/src/utils/__tests__/get-import-nodes-matched-group.spec.ts
+++ b/src/utils/__tests__/get-import-nodes-matched-group.spec.ts
@@ -43,6 +43,69 @@ test('should return correct matched groups', () => {
     ]);
 });
 
+test('should return type imports as part of a matching group if no type-specific group is present', () => {
+    const code = `
+import type { ExternalType } from 'external-type-module';
+import type { InternalType } from './internal-type-module';
+import { externalFn } from 'external-fn-module';
+import { internalFn } from './internal-fn-module';
+    `
+    const importNodes = getImportNodes(code,{
+        plugins: ['typescript'],
+    });
+    const importOrder = [
+        '^[^.].*',
+        '^[.].*',
+    ];
+
+    let matchedGroups: string[] = [];
+    for (const importNode of importNodes) {
+        const matchedGroup = getImportNodesMatchedGroup(
+            importNode,
+            importOrder,
+        );
+        matchedGroups.push(matchedGroup);
+    }
+    expect(matchedGroups).toEqual([
+        '^[^.].*',
+        '^[.].*',
+        '^[^.].*',
+        '^[.].*',
+    ]);
+});
+
+test('should return type imports as part of a type-specific group even if a matching non-type specific group precedes it', () => {
+    const code = `
+import type { ExternalType } from 'external-type-module';
+import type { InternalType } from './internal-type-module';
+import { externalFn } from 'external-fn-module';
+import { internalFn } from './internal-fn-module';
+    `
+    const importNodes = getImportNodes(code, {
+        plugins: ['typescript'],
+    });
+    const importOrder = [
+        '^[^.].*',
+        '^[.].*',
+        '<TS_TYPES>^[.].*',
+    ];
+
+    let matchedGroups: string[] = [];
+    for (const importNode of importNodes) {
+        const matchedGroup = getImportNodesMatchedGroup(
+            importNode,
+            importOrder,
+        );
+        matchedGroups.push(matchedGroup);
+    }
+    expect(matchedGroups).toEqual([
+        '^[^.].*',
+        '<TS_TYPES>^[.].*',
+        '^[^.].*',
+        '^[.].*',
+    ]);
+});
+
 test('should return THIRD_PARTY_MODULES as matched group with empty order list', () => {
     const importNodes = getImportNodes(code);
     const importOrder: string[] = [];

--- a/src/utils/get-import-nodes-matched-group.ts
+++ b/src/utils/get-import-nodes-matched-group.ts
@@ -22,21 +22,35 @@ export const getImportNodesMatchedGroup = (
             : new RegExp(group),
     }));
 
-    for (const { group, regExp } of groupWithRegExp) {
+    // finding the group for non-type imports is easy: it's the first group that matches.
+    // however, for type imports, we need to make sure that we don't match a non-type group
+    // that's earlier in the list than a type-specific group that would otherwise match.
+    // so we need to get all matching groups, look for the first matching _type-specific_ group,
+    // and if it exists, return it. otherwise, return the first matching group if there is one.
+    const matchingGroups = groupWithRegExp.filter(({ group, regExp }) => {
         if (
-            (group.startsWith(TYPES_SPECIAL_WORD) &&
-                node.importKind !== 'type') ||
-            (!group.startsWith(TYPES_SPECIAL_WORD) &&
-                node.importKind === 'type')
-        )
-            continue;
+            group.startsWith(TYPES_SPECIAL_WORD) &&
+            node.importKind !== 'type'
+        ) {
+            return false;
+        } else {
+            return node.source.value.match(regExp) !== null;
+        }
+    });
 
-        const matched = node.source.value.match(regExp) !== null;
-        if (matched) return group;
+    if (matchingGroups.length === 0) {
+        return node.importKind === 'type' &&
+            importOrder.find(
+                (group) => group === THIRD_PARTY_TYPES_SPECIAL_WORD,
+            )
+            ? THIRD_PARTY_TYPES_SPECIAL_WORD
+            : THIRD_PARTY_MODULES_SPECIAL_WORD;
+    } else if (node.importKind !== 'type') {
+        return matchingGroups[0].group;
+    } else {
+        for (const { group } of matchingGroups) {
+            if (group.startsWith(TYPES_SPECIAL_WORD)) return group;
+        }
+        return matchingGroups[0].group;
     }
-
-    return node.importKind === 'type' &&
-        importOrder.find((group) => group === THIRD_PARTY_TYPES_SPECIAL_WORD)
-        ? THIRD_PARTY_TYPES_SPECIAL_WORD
-        : THIRD_PARTY_MODULES_SPECIAL_WORD;
 };

--- a/tests/ImportsSeparated/__snapshots__/ppsi.spec.js.snap
+++ b/tests/ImportsSeparated/__snapshots__/ppsi.spec.js.snap
@@ -61,6 +61,25 @@ export const a = 1;
 
 `;
 
+exports[`import-with-type-imports-together.ts - typescript-verify: import-with-type-imports-together.ts 1`] = `
+import { foo } from "@server/foo"
+import type { Quux } from "./quux"
+import { Link } from "@ui/Link"
+import type { Bar } from "@server/bar"
+import type { LinkProps } from "@ui/Link/LinkProps"
+import { baz } from "./baz"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import type { Bar } from "@server/bar";
+import { foo } from "@server/foo";
+
+import { Link } from "@ui/Link";
+import type { LinkProps } from "@ui/Link/LinkProps";
+
+import { baz } from "./baz";
+import type { Quux } from "./quux";
+
+`;
+
 exports[`imports-with-comments.ts - typescript-verify: imports-with-comments.ts 1`] = `
 // I am top level comment in this file.
 // I am second line of top level comment in this file.

--- a/tests/ImportsSeparated/import-with-type-imports-together.ts
+++ b/tests/ImportsSeparated/import-with-type-imports-together.ts
@@ -1,0 +1,6 @@
+import { foo } from "@server/foo"
+import type { Quux } from "./quux"
+import { Link } from "@ui/Link"
+import type { Bar } from "@server/bar"
+import type { LinkProps } from "@ui/Link/LinkProps"
+import { baz } from "./baz"


### PR DESCRIPTION
it looks like #153 introduced a bug whereby `import type ...` imports would no longer be sorted with their matching group even if a type-specific group was not present. (see #329 for more details). this pr changes the matching logic such that:

- non-type imports go in the first matching group if there is one
- type imports go in the first matching type-specific group if there is one, or the first matching non-type-specific group if there is one
- otherwise the behaviour remains unchanged, they go in the `THIRD_PARTY_TYPES_SPECIAL_WORD` or `THIRD_PARTY_MODULES_SPECIAL_WORD` groups depending on the node type and whether the `THIRD_PARTY_TYPES_SPECIAL_WORD` exists in the config.

as this behaviour is starting to feel a little complex i've added a comment in the code - i see there's not a ton of comments so happy to take it out if it's against house style. i also don't love the code so refactoring suggestions welcomed.

this fixes #329  - i've tested it on my codebase and the incorrect ordering changes introduced by 5.0.0 were reversed.