### PR TITLE
Fix conditional import of prettier-plugin-svelte

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,10 +85,14 @@ module.exports = {
             ...htmlParsers.vue,
             preprocess: vuePreprocessor,
         },
-        svelte: {
-            ...svelteParsers.parsers.svelte,
-            preprocess: sveltePreprocessor,
-        },
+        ...(!!svelteParsers.parsers
+            ? {
+                  svelte: {
+                      ...svelteParsers.parsers.svelte,
+                      preprocess: sveltePreprocessor,
+                  },
+              }
+            : {}),
     },
     options,
 };


### PR DESCRIPTION
As @lmeerma points out in #330 the issue with conditionally importing the svelte plugin is caused by trying to access a key on the potentially undefined `parsers` value. This PR fixes this to avoid the issue. Tested on my codebase and works great.