### PR TITLE
fix: type error during svelte init

### DIFF
--- a/src/utils/create-svelte-parsers.ts
+++ b/src/utils/create-svelte-parsers.ts
@@ -1,8 +1,8 @@
 export function createSvelteParsers() {
     try {
-        var { parsers } = require('prettier-plugin-svelte');
+        const { parsers } = require('prettier-plugin-svelte');
+        return { parsers }
     } catch {
-        return {};
+        return { parsers: {} };
     }
-    return { parsers };
 }


### PR DESCRIPTION
On a system without `prettier-plugin-svelte` with the last patch:

```
> function createSvelteParsers() {
...     try {
...         var { parsers } = require('prettier-plugin-svelte');
...     } catch {
...         return {}
...     }
...     return { parsers }
... }
undefined
> console.log({ ...createSvelteParsers().parsers.svelte })
Uncaught TypeError: Cannot read properties of undefined (reading 'svelte')
```

This PR fixes that.