### PR TITLE
fix: import sorting with interpreter command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ lib/
 .idea
 
 package-lock.json
+
+# macOS utility files
+.DS_Store

--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -36,7 +36,7 @@ export function preprocessor(code: string, options: PrettierOptions) {
 
     // short-circuit if there are no import declaration
     if (importNodes.length === 0) return code;
-    if (isSortImportsIgnored(importNodes)) return code;
+    if (isSortImportsIgnored(importNodes, !!interpreter)) return code;
 
     const allImports = getSortedNodes(importNodes, {
         importOrder,

--- a/src/utils/is-sort-imports-ignored.ts
+++ b/src/utils/is-sort-imports-ignored.ts
@@ -3,10 +3,10 @@ import { Statement } from '@babel/types';
 import { sortImportsIgnoredComment } from '../constants';
 import { getAllCommentsFromNodes } from './get-all-comments-from-nodes';
 
-export const isSortImportsIgnored = (nodes: Statement[]) =>
+export const isSortImportsIgnored = (nodes: Statement[], hasInterpreter: boolean ) =>
     getAllCommentsFromNodes(nodes).some(
         (comment) =>
             comment.loc &&
-            comment.loc.start.line === 1 &&
+            comment.loc.start.line === (hasInterpreter ? 2 : 1) &&
             comment.value.includes(sortImportsIgnoredComment),
     );


### PR DESCRIPTION
Hi,

This tiny fix aimed to close case with combination of ignore comment and interpreter directive. Interpreter directive has to be on the first line, thus in this case comment with ignoring would be on 2nd line instead of the 1st. 

like this

```ts
#!/usr/bin/env node
// sort-imports-ignore
```
Also, I put .DS_Store file to gitignore. It's a common utility file within Mac OS. It creates it in every directory.