### PR TITLE
Add test case showing issues with 'use server'-like directives

### DIFF
--- a/tests/TopLevelCommentsWithUse/__snapshots__/ppsi.spec.js.snap
+++ b/tests/TopLevelCommentsWithUse/__snapshots__/ppsi.spec.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`top-level-comments.ts - typescript-verify: top-level-comments.ts 1`] = `
+// This is a top level comment that should not be duplicated
+// This is another comment that should stay at the top
+
+"use server";
+
+import z from 'z';
+import c from 'c';
+import b from 'b';
+import a from 'a';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// This is a top level comment that should not be duplicated
+// This is another comment that should stay at the top
+
+"use server";
+
+import a from "a";
+import b from "b";
+import c from "c";
+import z from "z";
+`;

--- a/tests/TopLevelCommentsWithUse/ppsi.spec.js
+++ b/tests/TopLevelCommentsWithUse/ppsi.spec.js
@@ -1,0 +1,9 @@
+run_spec(__dirname, ['typescript'], {
+  importOrderParserPlugins: ['typescript'],
+  importOrderSeparation: true,
+  importOrderSortSpecifiers: true,
+  importOrder: [
+    "^@/(.*)$",
+    "^[.]"
+  ],
+});

--- a/tests/TopLevelCommentsWithUse/top-level-comments.ts
+++ b/tests/TopLevelCommentsWithUse/top-level-comments.ts
@@ -1,0 +1,9 @@
+// This is a top level comment that should not be duplicated
+// This is another comment that should stay at the top
+
+"use server";
+
+import z from 'z';
+import c from 'c';
+import b from 'b';
+import a from 'a';


### PR DESCRIPTION
As https://github.com/trivago/prettier-plugin-sort-imports/issues/344 noticed, if you have a `"use client"` or `"use server"` directive at the top of your file, and a comment _above_ it, this plugin will duplicate the comment below the sorted imports. It doesn't happen if the directive is above the opening comment. Failing snapshot test should demonstrate.