### PR TITLE
[Test] Stop ignoring exceptions thrown in snapshot tests

### DIFF
--- a/test-setup/run_spec.mjs
+++ b/test-setup/run_spec.mjs
@@ -45,7 +45,9 @@ function run_spec(dirname, parsers, options) {
                         raw(source + '~'.repeat(80) + '\n' + result),
                     ).toMatchSnapshot(filename);
                 } catch (e) {
-                    console.error(e, path);
+                    throw new Error(
+                        `Problem occurred in ${path} file: ${error.name}`,
+                    );
                 }
             });
 


### PR DESCRIPTION

Summary:
This logic can hide breakages and cause tests to pass when the
underlying logic is actually broken. I encountered these hidden
breakages while working on some further feature changes, and figured
it was appropriate to fix this first.

As all existing tests pass without the try/catch, this change is
effectively a no-op.

Test Plan:
`yarn install && yarn run test ./tests/`
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/trivago/prettier-plugin-sort-imports/pull/355).
* #359
* #358
* #357
* #356
* __->__ #355
* #354