### PR TITLE
[Feature] importOrderIgnoreHeaderComments option

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,57 @@ The import attributes/assertions syntax:
 
 _Default behavior:_ When not specified, @babel/generator will try to match the style in the input code based on the AST shape.
 
+#### `importOrderIgnoreHeaderComments`
+
+**type**: `number`
+
+**default value**: `-1`
+
+How many comments at the start of the code to ignore while attaching comments to imports for sorting.
+
+This option is useful for projects that use a license header or similar comments at the start of the code, to
+ensure that whitespace around header comments is maintained, and header comments are not accidentally associated
+with the first import and sorted away from the start of the code.
+
+Negative values, including the default value of -1, preserve how this plugin has historically handled comments
+immediately before the first import statement. When negative, all comments immediately before the first import
+will be placed at the top of the import list. However, this has limitations:
+
+- Whitespace IS NOT maintained between these comments. If one of the comments is maintained by a linter /
+  formatter, and that tool expects whitespace to be preserved, it may result in conflicts where the code fails
+  to converge.
+- If the first import is sorted further down the list, comments intended to be attached to the first import
+  will not be sorted along with the import.
+
+```
+"importOrderIgnoreHeaderComments": 1,
+```
+
+#### `importOrderIgnoreHeaderCommentTypes`
+
+**type**: `'All' | 'CommentBlock' | 'CommentLine'`
+
+**default value**: `'All'`
+
+The type of comments ignored when using importOrderIgnoreHeaderComments option.
+
+If an unspecified comment type is encountered while evaluating importOrderIgnoreHeaderComments, it and all
+following comments will be sorted with the first import.
+
+```
+"importOrderIgnoreHeaderCommentTypes": "CommentBlock",
+```
+
+### Ignoring import ordering
+
+In some cases it's desired to ignore import ordering, specifically if you require to instantiate a common service or polyfill in your application logic before all the other imports. The plugin supports the `// sort-imports-ignore` comment, which will exclude the file from ordering the imports.
+
+```javascript
+// sort-imports-ignore
+import './polyfills';
+
+import foo from 'foo'
+```
 
 ### How does import sort work ?
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,30 @@ const options: Options = {
         default: 'with',
         description: 'Provide a keyword for import attributes',
     },
+    importOrderIgnoreHeaderComments: {
+        type: 'int',
+        category: 'Global',
+        default: -1,
+        description: 'Number of header comments to ignore when sorting imports',
+    },
+    importOrderIgnoreHeaderCommentTypes: {
+        type: 'choice',
+        category: 'Global',
+        default: 'All',
+        choices: [
+            { value: 'All', description: 'Consider all comments' },
+            {
+                value: 'CommentBlock',
+                description: 'Only consider block comments',
+            },
+            {
+                value: 'CommentLine',
+                description: 'Only consider single line comments',
+            },
+        ],
+        description:
+            'Types of comments to consider when evaluating importOrderIgnoreHeaderComments',
+    },
 };
 
 export default {

--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -20,6 +20,7 @@ export function preprocessor(code: string, options: PrettierOptions) {
         importOrderSortByLength,
         importOrderSideEffects,
         importOrderImportAttributesKeyword,
+        importOrderIgnoreHeaderComments,
     } = options;
 
     const parserOptions: ParserOptions = {
@@ -36,21 +37,27 @@ export function preprocessor(code: string, options: PrettierOptions) {
         importNodes,
         injectIdx,
     }: { importNodes: ImportDeclaration[]; injectIdx: number } =
-        extractASTNodes(ast);
+        extractASTNodes(ast, options);
 
     // short-circuit if there are no import declaration
     if (importNodes.length === 0) return code;
     if (isSortImportsIgnored(getAllCommentsFromNodes(importNodes))) return code;
 
-    const allImports = getSortedNodes(importNodes, {
-        importOrder,
-        importOrderCaseInsensitive,
-        importOrderSeparation,
-        importOrderGroupNamespaceSpecifiers,
-        importOrderSortSpecifiers,
-        importOrderSortByLength,
-        importOrderSideEffects,
-    });
+    const maintainFirstNodeComments = importOrderIgnoreHeaderComments < 0;
+
+    const allImports = getSortedNodes(
+        importNodes,
+        {
+            importOrder,
+            importOrderCaseInsensitive,
+            importOrderSeparation,
+            importOrderGroupNamespaceSpecifiers,
+            importOrderSortSpecifiers,
+            importOrderSideEffects,
+            importOrderSortByLength,
+        },
+        maintainFirstNodeComments,
+    );
 
     return getCodeFromAst(allImports, code, injectIdx, {
         importOrderImportAttributesKeyword,

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type GetSortedNodes = (
         | 'importOrderSortByLength'
         | 'importOrderSideEffects'
     >,
+    maintainFirstNodeComments?: boolean,
 ) => ImportOrLine[];
 
 export interface ImportChunk {

--- a/src/utils/adjust-comments-on-sorted-nodes.ts
+++ b/src/utils/adjust-comments-on-sorted-nodes.ts
@@ -13,6 +13,7 @@ import { ImportOrLine } from '../types';
 export const adjustCommentsOnSortedNodes = (
     nodes: ImportDeclaration[],
     finalNodes: ImportOrLine[],
+    maintainFirstNodeComments: boolean = true,
 ) => {
     // maintain a copy of the nodes to extract comments from
     const finalNodesClone = finalNodes.map(clone);
@@ -24,11 +25,15 @@ export const adjustCommentsOnSortedNodes = (
 
     // insert comments other than the first comments
     finalNodes.forEach((node, index) => {
-        if (isEqual(nodes[0].loc, node.loc)) return;
-        // remove comments location to not confuse print AST
-        firstNodesComments?.forEach((comment) => {
-            delete comment.loc;
-        });
+        if (maintainFirstNodeComments) {
+            if (isEqual(nodes[0].loc, node.loc)) return;
+
+            // remove comments location to not confuse print AST
+            firstNodesComments?.forEach((comment) => {
+                delete comment.loc;
+            });
+        }
+
         addComments(
             node,
             'leading',
@@ -36,7 +41,7 @@ export const adjustCommentsOnSortedNodes = (
         );
     });
 
-    if (firstNodesComments) {
+    if (maintainFirstNodeComments && firstNodesComments) {
         addComments(finalNodes[0], 'leading', firstNodesComments);
     }
 };

--- a/src/utils/get-sorted-nodes.ts
+++ b/src/utils/get-sorted-nodes.ts
@@ -20,7 +20,11 @@ import { getSortedNodesByImportOrder } from './get-sorted-nodes-by-import-order.
  * @param nodes All import nodes that should be sorted.
  * @param options Options to influence the behavior of the sorting algorithm.
  */
-export const getSortedNodes: GetSortedNodes = (nodes, options) => {
+export const getSortedNodes: GetSortedNodes = (
+    nodes,
+    options,
+    maintainFirstNodeComments = true,
+) => {
     const { importOrderSeparation, importOrderSideEffects } = options;
 
     // Split nodes at each boundary between a side-effect node and a
@@ -67,7 +71,7 @@ export const getSortedNodes: GetSortedNodes = (nodes, options) => {
     }
 
     // Adjust the comments on the sorted nodes to match the original comments
-    adjustCommentsOnSortedNodes(nodes, finalNodes);
+    adjustCommentsOnSortedNodes(nodes, finalNodes, maintainFirstNodeComments);
 
     return finalNodes;
 };

--- a/tests/HeaderComments/__snapshots__/ppsi.spec.js.snap
+++ b/tests/HeaderComments/__snapshots__/ppsi.spec.js.snap
@@ -1,0 +1,116 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`block-header.ts - typescript-verify > block-header.ts 1`] = `
+/* Copyright header comment */
+
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/* Copyright header comment */
+
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+import { b } from "r" with { type: "json" };
+import thirdDisco0 from "third-disco0";
+import thirdParty0 from "third-party0";
+import otherthing3 from "@core/otherthing3";
+import something0 from "@core/something0";
+import something3 from "@core/something3";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+
+function add(a, b) {
+    return a + b;
+}
+
+`;
+
+exports[`interleaved-blocks.ts - typescript-verify > interleaved-blocks.ts 1`] = `
+/* Copyright header comment */
+
+// CommentLine that will be considered a header
+
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/* Copyright header comment */
+
+// CommentLine that will be considered a header
+
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+import { b } from "r" with { type: "json" };
+import thirdDisco0 from "third-disco0";
+import thirdParty0 from "third-party0";
+import otherthing3 from "@core/otherthing3";
+import something0 from "@core/something0";
+import something3 from "@core/something3";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+
+function add(a, b) {
+    return a + b;
+}
+
+`;
+
+exports[`line-header.ts - typescript-verify > line-header.ts 1`] = `
+// Copyright header comment
+
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Copyright header comment
+
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+import { b } from "r" with { type: "json" };
+import thirdDisco0 from "third-disco0";
+import thirdParty0 from "third-party0";
+import otherthing3 from "@core/otherthing3";
+import something0 from "@core/something0";
+import something3 from "@core/something3";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+
+function add(a, b) {
+    return a + b;
+}
+
+`;

--- a/tests/HeaderComments/block-header.ts
+++ b/tests/HeaderComments/block-header.ts
@@ -1,0 +1,18 @@
+/* Copyright header comment */
+
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}

--- a/tests/HeaderComments/interleaved-blocks.ts
+++ b/tests/HeaderComments/interleaved-blocks.ts
@@ -1,0 +1,20 @@
+/* Copyright header comment */
+
+// CommentLine that will be considered a header
+
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}

--- a/tests/HeaderComments/line-header.ts
+++ b/tests/HeaderComments/line-header.ts
@@ -1,0 +1,18 @@
+// Copyright header comment
+
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}

--- a/tests/HeaderComments/ppsi.spec.js
+++ b/tests/HeaderComments/ppsi.spec.js
@@ -1,0 +1,8 @@
+run_spec(__dirname, ["typescript"], {
+    importOrder: ['^@core/(.*)$', '^@server/(.*)', '^@ui/(.*)$', '^[./]'],
+    importOrderSeparation: false,
+    importOrderSideEffects: false,
+    importOrderParserPlugins: ['typescript'],
+    importOrderImportAttributesKeyword: 'with',
+    importOrderIgnoreHeaderComments: Number.MAX_SAFE_INTEGER,
+});

--- a/tests/HeaderCommentsBlock/__snapshots__/ppsi.spec.js.snap
+++ b/tests/HeaderCommentsBlock/__snapshots__/ppsi.spec.js.snap
@@ -1,0 +1,130 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`interleaved-blocks.ts - typescript-verify > interleaved-blocks.ts 1`] = `
+/* Copyright header comment */
+
+// CommentLine that will attach to the first import
+
+/* CommentBlock that will attach to the first import */
+
+// First import attached CommentLine
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/* Copyright header comment */
+
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+import { b } from "r" with { type: "json" };
+import thirdDisco0 from "third-disco0";
+// CommentLine that will attach to the first import
+
+/* CommentBlock that will attach to the first import */
+
+// First import attached CommentLine
+import thirdParty0 from "third-party0";
+import otherthing3 from "@core/otherthing3";
+import something0 from "@core/something0";
+import something3 from "@core/something3";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+
+function add(a, b) {
+    return a + b;
+}
+
+`;
+
+exports[`multi-block-header.ts - typescript-verify > multi-block-header.ts 1`] = `
+/* Copyright header comment */
+
+/* Secondary header CommentBlock */
+
+// First import attached CommentLine
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/* Copyright header comment */
+
+/* Secondary header CommentBlock */
+
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+import { b } from "r" with { type: "json" };
+import thirdDisco0 from "third-disco0";
+// First import attached CommentLine
+import thirdParty0 from "third-party0";
+import otherthing3 from "@core/otherthing3";
+import something0 from "@core/something0";
+import something3 from "@core/something3";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+
+function add(a, b) {
+    return a + b;
+}
+
+`;
+
+exports[`single-block-header.ts - typescript-verify > single-block-header.ts 1`] = `
+/* Copyright header comment */
+
+// First import attached CommentLine
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/* Copyright header comment */
+
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+import { b } from "r" with { type: "json" };
+import thirdDisco0 from "third-disco0";
+// First import attached CommentLine
+import thirdParty0 from "third-party0";
+import otherthing3 from "@core/otherthing3";
+import something0 from "@core/something0";
+import something3 from "@core/something3";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+
+function add(a, b) {
+    return a + b;
+}
+
+`;

--- a/tests/HeaderCommentsBlock/interleaved-blocks.ts
+++ b/tests/HeaderCommentsBlock/interleaved-blocks.ts
@@ -1,0 +1,23 @@
+/* Copyright header comment */
+
+// CommentLine that will attach to the first import
+
+/* CommentBlock that will attach to the first import */
+
+// First import attached CommentLine
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}

--- a/tests/HeaderCommentsBlock/multi-block-header.ts
+++ b/tests/HeaderCommentsBlock/multi-block-header.ts
@@ -1,0 +1,21 @@
+/* Copyright header comment */
+
+/* Secondary header CommentBlock */
+
+// First import attached CommentLine
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}

--- a/tests/HeaderCommentsBlock/ppsi.spec.js
+++ b/tests/HeaderCommentsBlock/ppsi.spec.js
@@ -1,0 +1,9 @@
+run_spec(__dirname, ["typescript"], {
+    importOrder: ['^@core/(.*)$', '^@server/(.*)', '^@ui/(.*)$', '^[./]'],
+    importOrderSeparation: false,
+    importOrderSideEffects: false,
+    importOrderParserPlugins: ['typescript'],
+    importOrderImportAttributesKeyword: 'with',
+    importOrderIgnoreHeaderComments: Number.MAX_SAFE_INTEGER,
+    importOrderIgnoreHeaderCommentTypes: 'CommentBlock',
+});

--- a/tests/HeaderCommentsBlock/single-block-header.ts
+++ b/tests/HeaderCommentsBlock/single-block-header.ts
@@ -1,0 +1,19 @@
+/* Copyright header comment */
+
+// First import attached CommentLine
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}

--- a/tests/HeaderCommentsLimit/__snapshots__/ppsi.spec.js.snap
+++ b/tests/HeaderCommentsLimit/__snapshots__/ppsi.spec.js.snap
@@ -1,0 +1,44 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`multi-block-header.ts - typescript-verify > multi-block-header.ts 1`] = `
+/* Copyright header comment */
+
+/* First import attached CommentBlock */
+
+// First import attached CommentLine
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/* Copyright header comment */
+
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+import { b } from "r" with { type: "json" };
+import thirdDisco0 from "third-disco0";
+/* First import attached CommentBlock */
+
+// First import attached CommentLine
+import thirdParty0 from "third-party0";
+import otherthing3 from "@core/otherthing3";
+import something0 from "@core/something0";
+import something3 from "@core/something3";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+
+function add(a, b) {
+    return a + b;
+}
+
+`;

--- a/tests/HeaderCommentsLimit/multi-block-header.ts
+++ b/tests/HeaderCommentsLimit/multi-block-header.ts
@@ -1,0 +1,21 @@
+/* Copyright header comment */
+
+/* First import attached CommentBlock */
+
+// First import attached CommentLine
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+// CommentLine attached to import
+import { a } from "b" with { type: "json" };
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+
+import { b } from "r" with { type: "json" };
+
+
+function add(a,b) {
+  return a + b;
+}

--- a/tests/HeaderCommentsLimit/ppsi.spec.js
+++ b/tests/HeaderCommentsLimit/ppsi.spec.js
@@ -1,0 +1,9 @@
+run_spec(__dirname, ["typescript"], {
+    importOrder: ['^@core/(.*)$', '^@server/(.*)', '^@ui/(.*)$', '^[./]'],
+    importOrderSeparation: false,
+    importOrderSideEffects: false,
+    importOrderParserPlugins: ['typescript'],
+    importOrderImportAttributesKeyword: 'with',
+    importOrderIgnoreHeaderComments: 1,
+    importOrderIgnoreHeaderCommentTypes: 'CommentBlock',
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -125,6 +125,48 @@ used to order imports within each match group.
      * _Default behavior:_ When not specified, @babel/generator will try to match the style in the input code based on the AST shape.
      */
     importOrderImportAttributesKeyword?: 'assert' | 'with' | 'with-legacy';
+
+    /**
+     * How many comments at the start of the code to ignore while attaching comments to imports for sorting.
+     *
+     * This option is useful for projects that use a license header or similar comments at the start of the code, to
+     * ensure that whitespace around header comments is maintained, and header comments are not accidentally associated
+     * with the first import and sorted away from the start of the code.
+     *
+     * Negative values, including the default value of -1, preserve how this plugin has historically handled comments
+     * immediately before the first import statement. When negative, all comments immediately before the first import
+     * will be placed at the top of the import list. However, this has limitations:
+     *
+     *  * Whitespace IS NOT maintained between these comments. If one of the comments is maintained by a linter /
+     *    formatter, and that tool expects whitespace to be preserved, it may result in conflicts where the code fails
+     *    to converge.
+     *  * If the first import is sorted further down the list, comments intended to be attached to the first import
+     *    will not be sorted along with the import.
+     *
+     * ```
+     * "importOrderIgnoreHeaderComments": 1,
+     * ```
+     *
+     * @default -1
+     */
+    importOrderIgnoreHeaderComments?: number;
+
+    /**
+     * The type of comments ignored when using importOrderIgnoreHeaderComments option.
+     *
+     * If an unspecified comment type is encountered while evaluating importOrderIgnoreHeaderComments, it and all
+     * following comments will be sorted with the first import.
+     *
+     * ```
+     * "importOrderIgnoreHeaderCommentTypes": "CommentBlock",
+     * ```
+     *
+     * @default "All"
+     */
+    importOrderIgnoreHeaderCommentTypes?:
+        | 'All'
+        | 'CommentBlock'
+        | 'CommentLine';
 }
 
 export type PrettierConfig = PluginConfig & Config;


### PR DESCRIPTION

Summary:
This commit adds the importOrderIgnoreHeaderComments options and all associated implementation.

The importOrderIgnoreHeaderComments option allows the plugin to
recognize that the first comments in code may be header files, and
preserve their contents and whitespace. This can help avoid
situations where this plugin and other tools conflict with expected
whitespace, resulting in formatter cycles.

Test Plan:
`yarn install && yarn run test --all`

Note: This diff adds new snapshot tests to cover the new functionality.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/trivago/prettier-plugin-sort-imports/pull/359).
* __->__ #359
* #358
* #357
* #356
* #355
* #354