### PR TITLE
docs: add pnpm install command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,22 @@ import { add, filter, repeat } from '../utils';
 
 ### Install
 
-npm
+using npm
 
 ```shell script
 npm install --save-dev @trivago/prettier-plugin-sort-imports
 ```
 
-or, using yarn
+using yarn
 
 ```shell script
 yarn add --dev @trivago/prettier-plugin-sort-imports
+```
+
+using pnpm
+
+```shell script
+pnpm add -D @trivago/prettier-plugin-sort-imports
 ```
 
 **Note: If you are migrating from v2.x.x to v3.x.x, [Please Read Migration Guidelines](./docs/MIGRATION.md)**


### PR DESCRIPTION
# Summary

`pnpm` is popular enough now that its install command is frequently mentioned alongside `npm` and `yarn` in install instructions of modern projects. This PR adds the pnpm version of the install command to the README of this project.

# Examples

* https://eslint.org/docs/latest/use/getting-started
* https://zod.dev/?id=installation
* https://orm.drizzle.team/docs/get-started/postgresql-new