### PR TITLE
Require node >= 20.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20.x, 22.x]
+        node: [20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18.x, 20.x, 22.x]
+        node: [20.x, 22.x]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "svelte": "4.x || 5.x"
   },
   "engines": {
-    "node": ">18.12"
+    "node": ">= 20"
   },
   "peerDependenciesMeta": {
     "@vue/compiler-sfc": {


### PR DESCRIPTION
Node 18 is EOL and holds us back on a few things. We may want to consider dropping support for 18.x