### PR TITLE
Fix recognising mandatory prefix built-in imports

### DIFF
--- a/src/utils/is-builtin-module.ts
+++ b/src/utils/is-builtin-module.ts
@@ -1,5 +1,10 @@
 import { builtinModules } from 'module';
 
+/** Every built-in importable path, including those prefixed with `node:`. */
+const BUILTIN_PATHS = new Set(
+    builtinModules.flatMap((m) => (m.startsWith("node:") ? [m] : [m, `node:${m}`])),
+);
+
 /**
  * Check if a module name is a Node.js builtin module.
  * This includes both the traditional names (e.g., 'fs') and the
@@ -8,13 +13,5 @@ import { builtinModules } from 'module';
  * @param moduleName The module name to check
  * @returns True if the module is a Node.js builtin module
  */
-export const isBuiltinModule = (moduleName: string): boolean => {
-    // Handle node: prefixed modules
-    if (moduleName.startsWith('node:')) {
-        const withoutPrefix = moduleName.slice(5);
-        return builtinModules.includes(withoutPrefix);
-    }
-
-    // Handle traditional module names
-    return builtinModules.includes(moduleName);
-};
+export const isBuiltinModule = (moduleName: string): boolean =>
+    BUILTIN_PATHS.has(moduleName);


### PR DESCRIPTION
Some build-in Node modules, like `node:test`, have to be imported as `node:test`, not just `test`. The old version did not consider these to be built-in.

The new implementation also ought to be faster, being a single `Set` look-up.