### PR TITLE
Add support for @prettier/plugin-oxc parsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     },
     "devDependencies": {
         "@babel/core": "^7.26.7",
+        "@prettier/plugin-oxc": "^0.1.3",
         "@types/babel__core": "^7.20.5",
         "@types/babel__generator": "^7.27.0",
         "@types/babel__traverse": "^7.20.7",
@@ -61,6 +62,7 @@
         "vitest": "^3.2.4"
     },
     "peerDependencies": {
+        "@prettier/plugin-oxc": ">= 0.1.0",
         "@vue/compiler-sfc": "3.x",
         "prettier": "2.x - 3.x",
         "prettier-plugin-ember-template-tag": ">= 2.0.0",
@@ -71,6 +73,9 @@
         "node": ">= 20"
     },
     "peerDependenciesMeta": {
+        "@prettier/plugin-oxc": {
+            "optional": true
+        },
         "@vue/compiler-sfc": {
             "optional": true
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,11 @@ import { createSvelteParsers } from './utils/create-svelte-parsers.js';
 const emberParsers = await createEmberParsers();
 const svelteParsers = await createSvelteParsers();
 
+let oxcParsers: Record<string, any> = {};
+try {
+    oxcParsers = (await import('@prettier/plugin-oxc')).parsers;
+} catch {}
+
 const options: Options = {
     importOrderExclude: {
         type: 'path',
@@ -126,6 +131,18 @@ export default {
                   'ember-template-tag': {
                       ...emberParsers.parsers['ember-template-tag'],
                       preprocess: emberPreprocessor,
+                  },
+              }
+            : {}),
+        ...(oxcParsers.oxc
+            ? {
+                  oxc: {
+                      ...oxcParsers.oxc,
+                      preprocess: defaultPreprocessor,
+                  },
+                  'oxc-ts': {
+                      ...oxcParsers['oxc-ts'],
+                      preprocess: defaultPreprocessor,
                   },
               }
             : {}),


### PR DESCRIPTION
## Problem

[`@prettier/plugin-oxc`](https://github.com/nicolo-ribaudo/prettier-plugin-oxc) registers `oxc` and `oxc-ts` parsers that override Prettier's built-in `babel` and `typescript` parsers for JS/TS/JSX/TSX files. Since this plugin only attaches its import-sorting `preprocess` hook to the `babel`, `typescript`, `flow`, `vue`, `svelte`, and `ember-template-tag` parsers, **import sorting is silently skipped** when `@prettier/plugin-oxc` is active.

This is because Prettier auto-detects the parser from the file extension, and when OXC is loaded it maps `.ts`/`.tsx`/`.js`/`.jsx` to `oxc-ts`/`oxc` instead of `typescript`/`babel`. The OXC parsers have no `preprocess` hook, so the sort-imports preprocessing never runs.

## Solution

This PR adds `oxc` and `oxc-ts` parser entries that compose OXC's parser with the sort-imports `defaultPreprocessor`. The import of `@prettier/plugin-oxc` is wrapped in a try/catch so it remains fully optional — if the OXC plugin is not installed, nothing changes.

Changes:
- **`src/index.ts`**: Dynamically import `@prettier/plugin-oxc` (with try/catch fallback) and add `oxc`/`oxc-ts` parser entries with `preprocess: defaultPreprocessor`
- **`package.json`**: Add `@prettier/plugin-oxc` as an optional `peerDependency` (>= 0.1.0) and as a `devDependency` for testing

## How it works

The `preprocess` hook operates on source text using `@babel/parser` to extract and reorder imports, then returns the modified source text. This is independent of the downstream parser (OXC), which receives the already-sorted source. OXC's `parse`, `astFormat`, and other properties are preserved via object spread.

## Testing

Verified manually:
1. Created a `.ts` file with deliberately out-of-order imports
2. Ran prettier with both `@prettier/plugin-oxc` and this patched plugin
3. Imports were correctly sorted according to `importOrder` config
4. Without the patch, imports were left unsorted