### PR TITLE
feat: add importOrderMergeDuplicateImports option to merge same-path imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,41 @@ import c from 'c'
 ```
 
 
+### `importOrderMergeDuplicateImports`
+**type**: `boolean`
+**default value**: `false`
+
+When enabled, multiple import declarations that share the same module source are merged into a single declaration whenever doing so is syntactically valid. Useful for keeping the import block free of incidental duplication after refactors.
+
+Example:
+
+Initial file:
+
+```ts
+import { A } from 'path-to-A';
+import { type B } from 'path-to-A';
+
+import D from './m';
+import { named } from './m';
+```
+
+When sorted with this option enabled:
+
+```ts
+import { A, type B } from 'path-to-A';
+
+import D, { named } from './m';
+```
+
+Imports are deliberately left untouched whenever merging would not be safe — including:
+- A namespace import (`import * as N`) combined with named specifiers from the same path.
+- Two declarations that both define a default specifier with different local names.
+- Two namespace declarations with different local names.
+- Declarations that disagree on their import attributes/assertions (`with { type: "json" }` / `assert { ... }`).
+- A type-only declaration whose default or namespace specifier would need a specifier-level `type` modifier in the merged result (TypeScript does not allow `type` on default or namespace specifiers).
+
+Side-effect-only declarations (e.g. `import './m'`) are absorbed when another import for the same module already exists, since the resulting declaration still triggers the side effect.
+
 ### Ignoring import ordering
 
 In some cases it's desired to ignore import ordering, specifically if you require to instantiate a common service or polyfill in your application logic before all the other imports. The plugin supports the `// sort-imports-ignore` comment, which will exclude the file from ordering the imports.

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,13 @@ const options: Options = {
         default: true,
         description: 'Should side effects be sorted?',
     },
+    importOrderMergeDuplicateImports: {
+        type: 'boolean',
+        category: 'Global',
+        default: false,
+        description:
+            'Should import declarations sharing the same module source be merged?',
+    },
     importOrderImportAttributesKeyword: {
         type: 'string',
         category: 'Global',

--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -20,6 +20,7 @@ export function preprocessor(code: string, options: PrettierOptions) {
         importOrderSortSpecifiers,
         importOrderSortByLength,
         importOrderSideEffects,
+        importOrderMergeDuplicateImports,
         importOrderImportAttributesKeyword,
         importOrderExclude,
         filepath,
@@ -62,9 +63,14 @@ export function preprocessor(code: string, options: PrettierOptions) {
         importOrderSortSpecifiers,
         importOrderSortByLength,
         importOrderSideEffects,
+        importOrderMergeDuplicateImports,
     });
 
-    return getCodeFromAst(allImports, code, injectIdx, {
-        importOrderImportAttributesKeyword,
-    });
+    return getCodeFromAst(
+        allImports,
+        code,
+        injectIdx,
+        { importOrderImportAttributesKeyword },
+        importNodes,
+    );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,8 +4,7 @@ import { RequiredOptions } from 'prettier';
 import { PluginConfig } from '../types';
 
 export interface PrettierOptions
-    extends Required<PluginConfig>,
-        RequiredOptions {}
+    extends Required<PluginConfig>, RequiredOptions {}
 
 export type ImportGroups = Record<string, ImportDeclaration[]>;
 export type ImportOrLine = ImportDeclaration | ExpressionStatement;
@@ -21,6 +20,7 @@ export type GetSortedNodes = (
         | 'importOrderSortSpecifiers'
         | 'importOrderSortByLength'
         | 'importOrderSideEffects'
+        | 'importOrderMergeDuplicateImports'
     >,
 ) => ImportOrLine[];
 

--- a/src/utils/__tests__/assemble-updated-code.spec.ts
+++ b/src/utils/__tests__/assemble-updated-code.spec.ts
@@ -28,6 +28,7 @@ test('it should remove nodes from the original code', async () => {
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
         importOrderSortByLength: null,
     });
     const allCommentsFromImports = getAllCommentsFromNodes(sortedNodes);
@@ -56,6 +57,7 @@ test('it should inject the generated code at the correct location', async () => 
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
         importOrderSortByLength: null,
     });
     const allCommentsFromImports = getAllCommentsFromNodes(sortedNodes);

--- a/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
+++ b/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
@@ -17,6 +17,7 @@ const getSortedImportNodes = (code: string, options?: ParserOptions) => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     });
 };
 

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -24,6 +24,7 @@ import a from 'a';
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     });
     const formatted = getCodeFromAst(sortedNodes, code);
     expect(await format(formatted, { parser: 'babel' })).toEqual(

--- a/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
@@ -33,6 +33,7 @@ test('it returns all sorted nodes', () => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNames(sorted)).toEqual([
@@ -79,6 +80,7 @@ test('it returns all sorted nodes case-insensitive', () => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNames(sorted)).toEqual([
@@ -125,6 +127,7 @@ test('it returns all sorted nodes with sort order', () => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNames(sorted)).toEqual([
@@ -171,6 +174,7 @@ test('it returns all sorted nodes with sort order case-insensitive', () => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNames(sorted)).toEqual([
         'c',
@@ -216,6 +220,7 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
         importOrderSortSpecifiers: true,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNames(sorted)).toEqual([
         'XY',
@@ -261,6 +266,7 @@ test('it returns all sorted import nodes with sorted import specifiers with case
         importOrderSortSpecifiers: true,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNames(sorted)).toEqual([
         'c',
@@ -306,6 +312,7 @@ test('it returns all sorted nodes with custom third party modules', () => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNames(sorted)).toEqual([
         'a',
@@ -332,6 +339,7 @@ test('it returns all sorted nodes with namespace specifiers at the top', () => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNames(sorted)).toEqual([
@@ -366,6 +374,7 @@ test('it returns the default separations if `importOrderSeparation` is false', (
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
         importOrderSortByLength: null,
     });
     expect(getSeparationData(sorted)).toEqual([
@@ -393,6 +402,7 @@ test('it returns default import module separations', () => {
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
         importOrderSortByLength: null,
     });
     expect(getSeparationData(sorted)).toEqual([
@@ -425,6 +435,7 @@ test('it returns targeted import module separations', () => {
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
         importOrderSortByLength: null,
     });
     expect(getSeparationData(sorted)).toEqual([
@@ -458,6 +469,7 @@ test('it never returns a separation at the top of the list (leading separator)',
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
         importOrderSortByLength: null,
     });
     expect(getSeparationData(sorted)).toEqual([
@@ -479,6 +491,7 @@ test('it never returns a separation at the top of the list (zero preceding impor
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
         importOrderSortByLength: null,
     });
     expect(getSeparationData(sorted)).toEqual([

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -49,6 +49,7 @@ test('it returns all sorted nodes', () => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNames(sorted)).toEqual([
@@ -95,6 +96,7 @@ test('it returns all sorted nodes case-insensitive', () => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNames(sorted)).toEqual([
@@ -141,6 +143,7 @@ test('it returns all sorted nodes with sort order', () => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNames(sorted)).toEqual([
@@ -187,6 +190,7 @@ test('it returns all sorted nodes with sort order case-insensitive', () => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNames(sorted)).toEqual([
         'c',
@@ -232,6 +236,7 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
         importOrderSortSpecifiers: true,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNames(sorted)).toEqual([
         'XY',
@@ -277,6 +282,7 @@ test('it returns all sorted import nodes with sorted import specifiers with case
         importOrderSortSpecifiers: true,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNames(sorted)).toEqual([
         'c',
@@ -322,6 +328,7 @@ test('it returns all sorted nodes with custom third party modules', () => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNames(sorted)).toEqual([
         'a',
@@ -348,6 +355,7 @@ test('it returns all sorted nodes with namespace specifiers at the top', () => {
         importOrderSortSpecifiers: false,
         importOrderSortByLength: null,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNames(sorted)).toEqual([
@@ -374,6 +382,7 @@ test('it returns all sorted nodes, sorted shortest to longest', () => {
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
         importOrderSortByLength: 'asc',
     }) as ImportDeclaration[];
     expect(getSortedNodesNames(sorted)).toEqual([
@@ -400,6 +409,7 @@ test('it returns all sorted nodes, sorted longest to shortest', () => {
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderSideEffects: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSortByLength: 'desc',
     }) as ImportDeclaration[];
     expect(getSortedNodesNames(sorted)).toEqual([
@@ -428,6 +438,7 @@ test('it returns all sorted nodes with types', () => {
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderSideEffects: true,
+        importOrderMergeDuplicateImports: false,
         importOrderSortByLength: null,
     }) as ImportDeclaration[];
 

--- a/src/utils/__tests__/merge-duplicate-imports.spec.ts
+++ b/src/utils/__tests__/merge-duplicate-imports.spec.ts
@@ -1,0 +1,164 @@
+import generateModule from '@babel/generator';
+import { ImportDeclaration } from '@babel/types';
+import { describe, expect, test } from 'vitest';
+
+import { getImportNodes } from '../get-import-nodes';
+import { mergeDuplicateImports } from '../merge-duplicate-imports';
+
+const generate = (generateModule as any).default || generateModule;
+
+const printNode = (node: ImportDeclaration) =>
+    generate(node, { retainLines: false, compact: true }).code.trim();
+
+const print = (nodes: ImportDeclaration[]) => nodes.map(printNode);
+
+const parse = (code: string) => getImportNodes(code, { errorRecovery: true });
+
+const tsParse = (code: string) =>
+    getImportNodes(code, {
+        plugins: ['typescript'],
+        errorRecovery: true,
+    });
+
+describe('mergeDuplicateImports', () => {
+    test('merges two named imports from the same path', () => {
+        const nodes = parse(`import { A } from 'm';\nimport { B } from 'm';`);
+        const merged = mergeDuplicateImports(nodes);
+        expect(print(merged)).toEqual([`import{A,B}from'm';`]);
+    });
+
+    test('deduplicates identical specifiers', () => {
+        // Parse the two declarations separately so the scope checker does
+        // not flag the deliberately duplicated `A` binding.
+        const nodes = [
+            ...parse(`import { A, B } from 'm';`),
+            ...parse(`import { A, C } from 'm';`),
+        ];
+        const merged = mergeDuplicateImports(nodes);
+        expect(print(merged)).toEqual([`import{A,B,C}from'm';`]);
+    });
+
+    test('merges default and named imports', () => {
+        const nodes = parse(`import D from 'm';\nimport { A } from 'm';`);
+        const merged = mergeDuplicateImports(nodes);
+        expect(print(merged)).toEqual([`import D,{A}from'm';`]);
+    });
+
+    test('merges default and namespace imports', () => {
+        const nodes = parse(`import D from 'm';\nimport * as N from 'm';`);
+        const merged = mergeDuplicateImports(nodes);
+        expect(print(merged)).toEqual([`import D,*as N from'm';`]);
+    });
+
+    test('absorbs side-effect imports into a matching declaration', () => {
+        const nodes = parse(`import 'm';\nimport { A } from 'm';`);
+        const merged = mergeDuplicateImports(nodes);
+        expect(merged).toHaveLength(1);
+        expect(print(merged)).toEqual([`import{A}from'm';`]);
+    });
+
+    test('absorbs trailing side-effect imports', () => {
+        const nodes = parse(`import { A } from 'm';\nimport 'm';`);
+        const merged = mergeDuplicateImports(nodes);
+        expect(print(merged)).toEqual([`import{A}from'm';`]);
+    });
+
+    test('does not merge namespace + named imports (invalid syntax)', () => {
+        const nodes = parse(`import * as N from 'm';\nimport { A } from 'm';`);
+        const merged = mergeDuplicateImports(nodes);
+        expect(merged).toHaveLength(2);
+    });
+
+    test('does not merge imports with conflicting default locals', () => {
+        const nodes = parse(`import D1 from 'm';\nimport D2 from 'm';`);
+        const merged = mergeDuplicateImports(nodes);
+        expect(merged).toHaveLength(2);
+    });
+
+    test('does not merge imports with conflicting namespace locals', () => {
+        const nodes = parse(
+            `import * as N1 from 'm';\nimport * as N2 from 'm';`,
+        );
+        const merged = mergeDuplicateImports(nodes);
+        expect(merged).toHaveLength(2);
+    });
+
+    test('leaves imports from different paths untouched', () => {
+        const nodes = parse(`import { A } from 'm';\nimport { B } from 'n';`);
+        const merged = mergeDuplicateImports(nodes);
+        expect(merged).toHaveLength(2);
+    });
+
+    test('merges three imports from the same path', () => {
+        const nodes = parse(
+            `import { A } from 'm';\nimport { B } from 'm';\nimport { C } from 'm';`,
+        );
+        const merged = mergeDuplicateImports(nodes);
+        expect(print(merged)).toEqual([`import{A,B,C}from'm';`]);
+    });
+
+    test('does not merge imports with different attributes', () => {
+        const nodes = parse(
+            `import { A } from 'm' with { type: 'json' };\nimport { B } from 'm';`,
+        );
+        const merged = mergeDuplicateImports(nodes);
+        expect(merged).toHaveLength(2);
+    });
+
+    test('merges imports with matching attributes', () => {
+        const nodes = parse(
+            `import { A } from 'm' with { type: 'json' };\nimport { B } from 'm' with { type: 'json' };`,
+        );
+        const merged = mergeDuplicateImports(nodes);
+        expect(merged).toHaveLength(1);
+    });
+
+    test('promotes named type-only imports when merging with a value import', () => {
+        const nodes = tsParse(
+            `import { A } from 'm';\nimport type { B } from 'm';`,
+        );
+        const merged = mergeDuplicateImports(nodes);
+        expect(print(merged)).toEqual([`import{A,type B}from'm';`]);
+    });
+
+    test('keeps importKind = type when both declarations are type-only', () => {
+        const nodes = tsParse(
+            `import type { A } from 'm';\nimport type { B } from 'm';`,
+        );
+        const merged = mergeDuplicateImports(nodes);
+        expect(merged).toHaveLength(1);
+        expect(merged[0].importKind).toBe('type');
+        expect(print(merged)).toEqual([`import type{A,B}from'm';`]);
+    });
+
+    test('does not merge type default with value named (would require type modifier on default)', () => {
+        const nodes = tsParse(
+            `import type D from 'm';\nimport { A } from 'm';`,
+        );
+        const merged = mergeDuplicateImports(nodes);
+        expect(merged).toHaveLength(2);
+    });
+
+    test('does not drop the type modifier on already-promoted specifiers when deduping', () => {
+        const nodes = tsParse(
+            `import { type A } from 'm';\nimport { A } from 'm';`,
+        );
+        const merged = mergeDuplicateImports(nodes);
+        // Differing specifier kinds (type vs value) are distinct specifiers
+        expect(print(merged)).toEqual([`import{type A,A}from'm';`]);
+    });
+
+    test('preserves leading comments from absorbed declarations', () => {
+        const nodes = parse(
+            `// keep me\nimport { A } from 'm';\n// also keep\nimport { B } from 'm';`,
+        );
+        const merged = mergeDuplicateImports(nodes);
+        expect(merged).toHaveLength(1);
+        const comments = (merged[0].leadingComments ?? []).map((c) =>
+            c.value.trim(),
+        );
+        expect(comments).toEqual(
+            expect.arrayContaining(['keep me', 'also keep']),
+        );
+    });
+});

--- a/src/utils/get-code-from-ast.ts
+++ b/src/utils/get-code-from-ast.ts
@@ -10,18 +10,31 @@ const generate = (generateModule as any).default || generateModule;
 
 /**
  * This function generate a code string from the passed nodes.
- * @param nodes all imports
- * @param originalCode
+ * @param nodes the imports to be emitted in their final order
+ * @param originalCode the source file's full text
+ * @param injectIdx the offset at which the generated imports are injected
+ * @param options generator options
+ * @param originalNodes the imports as they appear in `originalCode`; when
+ *   provided, these (rather than `nodes`) are used to determine which
+ *   ranges must be removed from the original source. This is required
+ *   when `nodes` was derived from `originalNodes` via a transformation
+ *   that drops or merges nodes (so that absorbed declarations no longer
+ *   appear in `nodes` but still need to be removed from the source).
  */
 export const getCodeFromAst = (
     nodes: Statement[],
     originalCode: string,
     injectIdx: number = 0,
     options?: Pick<PrettierOptions, 'importOrderImportAttributesKeyword'>,
+    originalNodes?: Statement[],
 ) => {
-    const allCommentsFromImports = getAllCommentsFromNodes(nodes);
+    const nodesForRemoval = originalNodes ?? nodes;
+    const allCommentsFromImports = getAllCommentsFromNodes(nodesForRemoval);
 
-    const nodesToRemoveFromCode = [...nodes, ...allCommentsFromImports];
+    const nodesToRemoveFromCode = [
+        ...nodesForRemoval,
+        ...allCommentsFromImports,
+    ];
 
     const newAST = file({
         type: 'Program',

--- a/src/utils/get-sorted-nodes.ts
+++ b/src/utils/get-sorted-nodes.ts
@@ -6,6 +6,7 @@ import {
 import { GetSortedNodes, ImportChunk, ImportOrLine } from '../types';
 import { adjustCommentsOnSortedNodes } from './adjust-comments-on-sorted-nodes.js';
 import { getSortedNodesByImportOrder } from './get-sorted-nodes-by-import-order.js';
+import { mergeDuplicateImports } from './merge-duplicate-imports.js';
 
 /**
  * This function returns the given nodes, sorted in the order as indicated by
@@ -21,7 +22,11 @@ import { getSortedNodesByImportOrder } from './get-sorted-nodes-by-import-order.
  * @param options Options to influence the behavior of the sorting algorithm.
  */
 export const getSortedNodes: GetSortedNodes = (nodes, options) => {
-    const { importOrderSeparation, importOrderSideEffects } = options;
+    const {
+        importOrderSeparation,
+        importOrderSideEffects,
+        importOrderMergeDuplicateImports,
+    } = options;
 
     // Split nodes at each boundary between a side-effect node and a
     // non-side-effect node, keeping both types of nodes together.
@@ -53,8 +58,13 @@ export const getSortedNodes: GetSortedNodes = (nodes, options) => {
             // do not sort side effect nodes
             finalNodes.push(...chunk.nodes);
         } else {
-            // sort non-side effect nodes
-            const sorted = getSortedNodesByImportOrder(chunk.nodes, options);
+            // Merge duplicates within the chunk so the sorter sees one
+            // declaration per unique module source. Done before sorting so
+            // that the merged result participates in regular ordering.
+            const chunkNodes = importOrderMergeDuplicateImports
+                ? mergeDuplicateImports(chunk.nodes)
+                : chunk.nodes;
+            const sorted = getSortedNodesByImportOrder(chunkNodes, options);
             finalNodes.push(...sorted);
         }
         if (importOrderSeparation) {

--- a/src/utils/merge-duplicate-imports.ts
+++ b/src/utils/merge-duplicate-imports.ts
@@ -1,0 +1,226 @@
+import {
+    ImportAttribute,
+    ImportDeclaration,
+    ImportDefaultSpecifier,
+    ImportNamespaceSpecifier,
+    ImportSpecifier,
+    addComments,
+} from '@babel/types';
+
+type AnyImportSpecifier =
+    | ImportSpecifier
+    | ImportDefaultSpecifier
+    | ImportNamespaceSpecifier;
+
+/**
+ * Merges import declarations that share the same module source within the
+ * given list. Imports are merged only when combining them produces
+ * syntactically valid code; in any ambiguous case the original declarations
+ * are preserved untouched.
+ *
+ * Merge rules:
+ *  - The module source (`from "..."`) must match.
+ *  - Import attributes/assertions (`with { ... }` / `assert { ... }`) must match.
+ *  - A namespace specifier (`* as N`) cannot coexist with named specifiers in
+ *    the same declaration; such pairs are left unmerged.
+ *  - Conflicting default specifiers with different local names are left unmerged.
+ *  - When merging a `import type` declaration with a value declaration, named
+ *    specifiers are promoted to specifier-level `type` (e.g. `{ type Foo }`).
+ *    Type declarations carrying a default or namespace specifier are not
+ *    merged with value declarations, since those specifier kinds cannot
+ *    carry a specifier-level `type` modifier.
+ *  - Side-effect-only imports (no specifiers) are absorbed into a matching
+ *    declaration when one exists; otherwise they are kept as-is.
+ *  - Duplicate specifiers (same imported and local name with the same type
+ *    modifier) are deduplicated.
+ *  - Leading comments from absorbed declarations are appended to the merged
+ *    declaration so no user comment is silently dropped.
+ */
+export const mergeDuplicateImports = (
+    nodes: ImportDeclaration[],
+): ImportDeclaration[] => {
+    const result: ImportDeclaration[] = [];
+    const indexByKey = new Map<string, number>();
+
+    for (const node of nodes) {
+        const key = `${node.source.value}::${attributesFingerprint(node)}`;
+        const existingIdx = indexByKey.get(key);
+
+        if (existingIdx === undefined) {
+            result.push(node);
+            indexByKey.set(key, result.length - 1);
+            continue;
+        }
+
+        const merged = tryMerge(result[existingIdx], node);
+        if (merged === null) {
+            // Keep both — leave the original as the "owner" of this key so
+            // any subsequent declaration tries to merge into it first.
+            result.push(node);
+        } else {
+            result[existingIdx] = merged;
+        }
+    }
+
+    return result;
+};
+
+const tryMerge = (
+    a: ImportDeclaration,
+    b: ImportDeclaration,
+): ImportDeclaration | null => {
+    // Side-effect-only declarations have no specifiers and carry no useful
+    // information beyond their existence — absorb into the other one.
+    if (b.specifiers.length === 0) {
+        return appendComments(a, b);
+    }
+    if (a.specifiers.length === 0) {
+        return appendComments(b, a);
+    }
+
+    const aHasNamespace = a.specifiers.some(isNamespaceSpecifier);
+    const bHasNamespace = b.specifiers.some(isNamespaceSpecifier);
+    const aHasNamed = a.specifiers.some(isImportSpecifier);
+    const bHasNamed = b.specifiers.some(isImportSpecifier);
+
+    if ((aHasNamespace && bHasNamed) || (bHasNamespace && aHasNamed)) {
+        return null;
+    }
+
+    const aDefault = a.specifiers.find(isDefaultSpecifier);
+    const bDefault = b.specifiers.find(isDefaultSpecifier);
+    if (aDefault && bDefault && aDefault.local.name !== bDefault.local.name) {
+        return null;
+    }
+
+    // Two namespace imports from the same path with different locals can't
+    // be combined into a single declaration.
+    const aNamespace = a.specifiers.find(isNamespaceSpecifier);
+    const bNamespace = b.specifiers.find(isNamespaceSpecifier);
+    if (
+        aNamespace &&
+        bNamespace &&
+        aNamespace.local.name !== bNamespace.local.name
+    ) {
+        return null;
+    }
+
+    const aKind = a.importKind ?? 'value';
+    const bKind = b.importKind ?? 'value';
+    const mixedKinds = aKind !== bKind;
+
+    if (mixedKinds) {
+        // To merge a type-only declaration into a value declaration each
+        // specifier from the type side must support a specifier-level `type`
+        // modifier — only `ImportSpecifier` does. Bail if the type side
+        // carries a default or namespace specifier.
+        const typeSide = aKind === 'type' ? a : b;
+        if (typeSide.specifiers.some((s) => !isImportSpecifier(s))) {
+            return null;
+        }
+    }
+
+    const resultKind: 'type' | 'value' =
+        aKind === 'type' && bKind === 'type' ? 'type' : 'value';
+
+    const aSpecs =
+        aKind === 'type' && resultKind === 'value'
+            ? a.specifiers.map(promoteToTypeSpecifier)
+            : a.specifiers;
+    const bSpecs =
+        bKind === 'type' && resultKind === 'value'
+            ? b.specifiers.map(promoteToTypeSpecifier)
+            : b.specifiers;
+
+    const mergedSpecifiers = dedupeSpecifiers([...aSpecs, ...bSpecs]);
+
+    const merged: ImportDeclaration = {
+        ...a,
+        specifiers: mergedSpecifiers,
+        importKind: resultKind,
+    };
+
+    return appendComments(merged, b);
+};
+
+const isImportSpecifier = (s: AnyImportSpecifier): s is ImportSpecifier =>
+    s.type === 'ImportSpecifier';
+
+const isDefaultSpecifier = (
+    s: AnyImportSpecifier,
+): s is ImportDefaultSpecifier => s.type === 'ImportDefaultSpecifier';
+
+const isNamespaceSpecifier = (
+    s: AnyImportSpecifier,
+): s is ImportNamespaceSpecifier => s.type === 'ImportNamespaceSpecifier';
+
+const promoteToTypeSpecifier = (
+    specifier: AnyImportSpecifier,
+): AnyImportSpecifier => {
+    if (!isImportSpecifier(specifier)) return specifier;
+    if (specifier.importKind === 'type') return specifier;
+    return { ...specifier, importKind: 'type' };
+};
+
+const dedupeSpecifiers = (
+    specifiers: AnyImportSpecifier[],
+): AnyImportSpecifier[] => {
+    const seen = new Set<string>();
+    const out: AnyImportSpecifier[] = [];
+    for (const spec of specifiers) {
+        const key = specifierKey(spec);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(spec);
+    }
+    return out;
+};
+
+const specifierKey = (spec: AnyImportSpecifier): string => {
+    if (isDefaultSpecifier(spec)) {
+        return `default::${spec.local.name}`;
+    }
+    if (isNamespaceSpecifier(spec)) {
+        return `namespace::${spec.local.name}`;
+    }
+    const imported =
+        spec.imported.type === 'Identifier'
+            ? spec.imported.name
+            : spec.imported.value;
+    const kind = spec.importKind ?? 'value';
+    return `named::${kind}::${imported}::${spec.local.name}`;
+};
+
+const attributesFingerprint = (node: ImportDeclaration): string => {
+    const attrs = getAttributes(node);
+    if (!attrs || attrs.length === 0) return '';
+    const parts = attrs
+        .map((attr) => {
+            const keyName =
+                attr.key.type === 'Identifier' ? attr.key.name : attr.key.value;
+            return `${keyName}=${attr.value.value}`;
+        })
+        .sort();
+    return parts.join('&');
+};
+
+const getAttributes = (
+    node: ImportDeclaration,
+): ImportAttribute[] | null | undefined => {
+    if (node.attributes && node.attributes.length > 0) return node.attributes;
+    // `assertions` is the legacy field for `assert { ... }` syntax. Both
+    // shapes share the `ImportAttribute` node type.
+    const assertions = (node as unknown as { assertions?: ImportAttribute[] })
+        .assertions;
+    return assertions;
+};
+
+const appendComments = (
+    target: ImportDeclaration,
+    source: ImportDeclaration,
+): ImportDeclaration => {
+    const leading = source.leadingComments;
+    if (!leading || leading.length === 0) return target;
+    addComments(target, 'leading', leading);
+    return target;
+};

--- a/tests/MergeDuplicateImports/__snapshots__/ppsi.spec.mjs.snap
+++ b/tests/MergeDuplicateImports/__snapshots__/ppsi.spec.mjs.snap
@@ -1,0 +1,81 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`merge-basic.ts - typescript-verify > merge-basic.ts 1`] = `
+import { A } from 'path-to-A';
+import { type B } from 'path-to-A';
+
+import { reduce } from 'lodash-es';
+import { debounce } from 'lodash-es';
+
+import D from './m';
+import { named } from './m';
+
+import './side-effect';
+import { sideEffectExport } from './side-effect';
+
+import { A as A1 } from '@core/m';
+import { B as B2, C } from '@core/m';
+
+const x = A;
+const y: B = {} as any;
+const z = sideEffectExport + A1 + B2 + C + D + named + reduce + debounce;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import { debounce, reduce } from "lodash-es";
+import { A, type B } from "path-to-A";
+import { A as A1, B as B2, C } from "@core/m";
+import D, { named } from "./m";
+import { sideEffectExport } from "./side-effect";
+
+const x = A;
+const y: B = {} as any;
+const z = sideEffectExport + A1 + B2 + C + D + named + reduce + debounce;
+
+`;
+
+exports[`merge-not-mergeable.ts - typescript-verify > merge-not-mergeable.ts 1`] = `
+import * as N from './ns';
+import { something } from './ns';
+
+import D1 from './conflict';
+import D2 from './conflict';
+
+import { A } from './attrs' with { type: 'json' };
+import { B } from './attrs';
+
+import type Foo from './type-default';
+import { Bar } from './type-default';
+
+const x = N;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import { A } from "./attrs" with { type: "json" };
+import { B } from "./attrs";
+import D1 from "./conflict";
+import D2 from "./conflict";
+import * as N from "./ns";
+import { something } from "./ns";
+import type Foo from "./type-default";
+import { Bar } from "./type-default";
+
+const x = N;
+
+`;
+
+exports[`merge-types.ts - typescript-verify > merge-types.ts 1`] = `
+import type { A } from './t';
+import type { B } from './t';
+
+import type { TFoo } from './mix';
+import { value } from './mix';
+
+import { existing, type alreadyType } from './ts-mixed';
+import type { newType } from './ts-mixed';
+
+const x: A = {} as any;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import { type TFoo, value } from "./mix";
+import type { A, B } from "./t";
+import { type alreadyType, existing, type newType } from "./ts-mixed";
+
+const x: A = {} as any;
+
+`;

--- a/tests/MergeDuplicateImports/merge-basic.ts
+++ b/tests/MergeDuplicateImports/merge-basic.ts
@@ -1,0 +1,18 @@
+import { A } from 'path-to-A';
+import { type B } from 'path-to-A';
+
+import { reduce } from 'lodash-es';
+import { debounce } from 'lodash-es';
+
+import D from './m';
+import { named } from './m';
+
+import './side-effect';
+import { sideEffectExport } from './side-effect';
+
+import { A as A1 } from '@core/m';
+import { B as B2, C } from '@core/m';
+
+const x = A;
+const y: B = {} as any;
+const z = sideEffectExport + A1 + B2 + C + D + named + reduce + debounce;

--- a/tests/MergeDuplicateImports/merge-not-mergeable.ts
+++ b/tests/MergeDuplicateImports/merge-not-mergeable.ts
@@ -1,0 +1,13 @@
+import * as N from './ns';
+import { something } from './ns';
+
+import D1 from './conflict';
+import D2 from './conflict';
+
+import { A } from './attrs' with { type: 'json' };
+import { B } from './attrs';
+
+import type Foo from './type-default';
+import { Bar } from './type-default';
+
+const x = N;

--- a/tests/MergeDuplicateImports/merge-types.ts
+++ b/tests/MergeDuplicateImports/merge-types.ts
@@ -1,0 +1,10 @@
+import type { A } from './t';
+import type { B } from './t';
+
+import type { TFoo } from './mix';
+import { value } from './mix';
+
+import { existing, type alreadyType } from './ts-mixed';
+import type { newType } from './ts-mixed';
+
+const x: A = {} as any;

--- a/tests/MergeDuplicateImports/ppsi.spec.mjs
+++ b/tests/MergeDuplicateImports/ppsi.spec.mjs
@@ -1,0 +1,6 @@
+run_spec(__dirname, ['typescript'], {
+    importOrder: ['^@core/(.*)$', '^@server/(.*)$', '^@ui/(.*)$', '^[./]'],
+    importOrderMergeDuplicateImports: true,
+    importOrderSortSpecifiers: true,
+    importOrderParserPlugins: ['typescript'],
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -111,6 +111,33 @@ used to order imports within each match group.
     importOrderSideEffects?: boolean;
 
     /**
+     * A boolean value to enable merging of import declarations that share the
+     * same module source. When enabled, multiple imports from the same path
+     * are collapsed into a single declaration whenever doing so is
+     * syntactically valid.
+     *
+     * For example, with this option enabled:
+     *
+     * ```ts
+     * import { A } from 'path-to-A';
+     * import { type A } from 'path-to-A';
+     * ```
+     *
+     * becomes:
+     *
+     * ```ts
+     * import { A, type A } from 'path-to-A';
+     * ```
+     *
+     * Imports are left untouched when merging would produce invalid syntax
+     * (e.g. combining a namespace import with named imports) or when the
+     * declarations have differing import attributes/assertions.
+     *
+     * @default false
+     */
+    importOrderMergeDuplicateImports?: boolean;
+
+    /**
      * The import attributes/assertions syntax to use. "with" for import "..." with { type: "json" },
      * "assert" for import "..." assert { type: "json" }, and "with-legacy" for import "..." with type: "json".
      *


### PR DESCRIPTION
# Description

## Summary

Closes #406.

Adds an opt-in `importOrderMergeDuplicateImports` boolean option (default `false`) that collapses multiple import declarations sharing the same module source into a single declaration, when doing so is syntactically valid.

### Example

Before:

```ts
import { A } from 'path-to-A';
import { type B } from 'path-to-A';
```

After:

```ts
import { A, type B } from 'path-to-A';
```

## Design

The merge step runs per non-side-effect chunk in `getSortedNodes`, before sorting, so the relative position of side-effect imports is preserved when `importOrderSideEffects: false`. The transformation is conservative: declarations are only merged when the result is unambiguously valid; in every other case the originals are kept untouched.

### Merge rules

Two import declarations are merged only when **all** of the following hold:

- Same module source (`from "..."`).
- Same import attributes/assertions (`with { ... }` / `assert { ... }`).
- Combining them produces valid syntax:
  - A namespace specifier (`* as N`) is **not** combined with named specifiers.
  - Two declarations with different default locals are kept separate.
  - Two declarations with different namespace locals are kept separate.
- TypeScript type handling:
  - Two `import type` declarations → merged, result stays `import type ...`.
  - `import type { X }` (named) + value declaration → named specifiers are promoted to specifier-level `type` modifiers (`{ type X }`).
  - `import type Default` / `import type * as Ns` + value declaration → **not** merged, because TypeScript does not allow a specifier-level `type` modifier on default or namespace specifiers.

Side-effect-only declarations (`import 'm'`) are absorbed into any other declaration for the same module, since the merged declaration still triggers the side effect. Identical specifiers across declarations are deduplicated by `(kind, imported name, local name, type modifier)`. Leading comments from absorbed declarations are appended onto the merged declaration so no user comment is silently dropped.

### Code-removal fix

`getCodeFromAst` now accepts an optional `originalNodes` parameter. When merging is applied, the emitted-imports list no longer contains the absorbed declarations, but `assembleUpdatedCode` still needs their `start`/`end` ranges to strip them from the original source. Passing the original `importNodes` through restores correct removal; the parameter is optional and backwards-compatible (defaults to the emitted list).

## Test plan

- [x] 18 unit tests in `src/utils/__tests__/merge-duplicate-imports.spec.ts` covering: same-path merge, dedup, default + named, default + namespace, side-effect absorption (leading and trailing), namespace + named refusal, conflicting defaults/namespaces refusal, three-way merge, attribute mismatch refusal, attribute match merge, named type-only promotion, both-type merge, type-default refusal, type-vs-value specifier distinction, comment preservation.
- [x] Snapshot fixtures in `tests/MergeDuplicateImports/` for `merge-basic.ts`, `merge-not-mergeable.ts`, `merge-types.ts`.
- [x] Full suite: 175 / 175 tests pass (existing 154 + new 21).
- [x] `tsc --noEmit` clean.
- [x] `prettier --check` clean on all touched files.
- [x] Public type added to `types/index.d.ts` with JSDoc; README section added under the existing options.

## Backwards compatibility

The option defaults to `false`, so existing users see identical output. No existing snapshot tests changed; the only modifications to existing test files are adding the new option key to inline `getSortedNodes(..., { ... })` calls so they continue to type-check against the widened `Pick<>`.
