### PR TITLE
Fix excessive blank lines after regenerated imports

### DIFF
--- a/src/utils/assemble-updated-code.ts
+++ b/src/utils/assemble-updated-code.ts
@@ -31,6 +31,7 @@ export const assembleUpdatedCode = (
             return Number.isSafeInteger(start) && Number.isSafeInteger(end);
         },
     );
+
     if (injectedCode !== undefined) {
         ranges.push({
             type: 'InjectedCode',
@@ -38,6 +39,7 @@ export const assembleUpdatedCode = (
             end: injectIdx,
         });
     }
+
     ranges.sort((a, b) => a.start - b.start);
 
     let result: string = '';
@@ -50,7 +52,13 @@ export const assembleUpdatedCode = (
         }
 
         if (injectedCode !== undefined && type === 'InjectedCode') {
-            result += injectedCode;
+            result += injectedCode.replace(/\n*$/, '\n\n');
+
+            // Skip blank lines immediately following the insertion point
+            const match = code.slice(idx).match(/^(?:[ \t]*\r?\n)+/);
+            if (match) {
+                idx += match[0].length;
+            }
         }
 
         if (end > idx) {


### PR DESCRIPTION
### Title

Fix excessive blank lines after regenerated imports

### Summary

When rebuilding files with sorted/regenerated imports, the assembler could produce multiple consecutive blank lines between the import block and the first non-import statement.

This occurred because the injected import source and the original file whitespace were both preserved. After imports were removed and reinserted, any blank lines that originally followed the import section remained in the output, causing the final file to contain more vertical spacing than intended.

### Root Cause

`assembleUpdatedCode` injects the generated import block at `injectIdx` but does not normalize whitespace immediately following the insertion point.

As a result, the output could contain:

```ts
[injected imports]\n\n
[existing blank lines from original source]\n\n
[first statement]
```

leading to three or more consecutive line feeds after the import section.

### Solution

Normalize the import boundary during code assembly by:

1. Ensuring the injected import block ends with exactly two line feeds (`\n\n`).
2. Skipping any blank lines that immediately follow the insertion point in the original source.

This guarantees a consistent formatting result:

```ts
import a from 'a';
import b from 'b';

const x = 1;
```

regardless of how many blank lines existed after the original imports.

### Benefits

* Produces stable and predictable formatting.
* Prevents accumulation of excessive whitespace after import sorting.
* Preserves the conventional single blank line between imports and executable code.
* Reduces formatting-only diffs in generated output.

### Example

#### Before

```ts
import a from 'a';
import b from 'b';



const value = 42;
```

#### After

```ts
import a from 'a';
import b from 'b';

const value = 42;
```

### Testing

Verified that:

* Files with no blank lines after imports remain correctly formatted.
* Files with one blank line after imports remain unchanged.
* Files with multiple blank lines after imports are normalized to a single visual blank line.
* Import injection continues to work correctly when imports are added, removed, or reordered.

Fixes #394 